### PR TITLE
feat(cicd): add Vitest and fix CI/CD pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,13 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint",
+    "lint": "eslint src/",
     "export": "next build",
     "predeploy": "npm run export",
-    "deploy": "gh-pages -d out"
+    "deploy": "gh-pages -d out",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "date-fns": "^4.1.0",
@@ -23,14 +26,21 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-datepicker": "^6.2.0",
     "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^4.3.4",
+    "@vitest/coverage-v8": "^3.1.1",
     "eslint": "^9",
     "eslint-config-next": "16.1.3",
     "gh-pages": "^6.3.0",
+    "jsdom": "^26.1.0",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.1.1"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: [],
+    passWithNoTests: true,
+    include: ['tests/**/*.{test,spec}.{ts,tsx}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      include: ['src/**/*.{ts,tsx}'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
Fixes #26

## Cambios

- Corrige script lint: `eslint` → `eslint src/` (ESLint 9 requiere target)
- Agrega scripts `test`, `test:watch`, `test:coverage` en package.json
- Instala Vitest + @testing-library como devDependencies
- Agrega vitest.config.ts con entorno jsdom y alias @/

## Pendiente (requiere edición manual de workflows)

- Permisos en claude.yml: read → write
- Eliminar step que imprime secret en claude.yml
- Corregir autenticación en claude-code-review.yml
- Agregar needs: [quality] en quality.yml job test
- Separar deploy PR vs. main en deploy.yml

Generated with [Claude Code](https://claude.ai/code)