### PR TITLE
fix: remove exposed OAuth token from workflow logs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,9 +30,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Print secret
-        run: echo "MY_SECRET CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
-        
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
Remove the 'Print secret' step that was printing the CLAUDE_CODE_OAUTH_TOKEN secret in plaintext to GitHub Actions logs.

Closes #30

Generated with [Claude Code](https://claude.ai/code)