### PR TITLE
fix: corregir permisos en claude-code-review.yml

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
Corrige los permisos del workflow de Claude Code Review para permitir publicar comentarios en PRs.

- `pull-requests: read` → `write`
- `issues: read` → `write`

Closes #34

Generated with [Claude Code](https://claude.ai/code)