### PR TITLE
fix: BookingModel - filtro por zona en validateCapacity y BookingValidationError

### DIFF
--- a/src/core/models/BookingModel.ts
+++ b/src/core/models/BookingModel.ts
@@ -1,5 +1,5 @@
 import { Booking, Trainer, ZoneType, ZONE_CONFIG } from '../types';
-import { BookingCapacityError } from '../types/errors';
+import { BookingCapacityError, BookingValidationError } from '../types/errors';
 import { IDataService } from '../repositories';
 import { isSameDay } from 'date-fns';
 
@@ -92,19 +92,19 @@ export class BookingModel {
 
   private validateBooking(booking: Omit<Booking, 'id'>): void {
     if (!booking.clientId.trim()) {
-      throw new Error('El cliente es requerido');
+      throw new BookingValidationError('El cliente es requerido');
     }
-    
+
     if (booking.duration < 30) {
-      throw new Error('La duración mínima es 30 minutos');
+      throw new BookingValidationError('La duración mínima es 30 minutos');
     }
-    
+
     if (booking.duration > 180) {
-      throw new Error('La duración máxima es 180 minutos');
+      throw new BookingValidationError('La duración máxima es 180 minutos');
     }
-    
+
     if (booking.date < new Date()) {
-      throw new Error('No se pueden hacer reservas en el pasado');
+      throw new BookingValidationError('No se pueden hacer reservas en el pasado');
     }
   }
 
@@ -120,8 +120,9 @@ export class BookingModel {
     
     // Filtrar reservas para la misma zona y horario
     const sameZoneBookings = existingBookings.filter(
-      b => b.date === booking.date && 
-           b.time === booking.time && 
+      b => b.date === booking.date &&
+           b.time === booking.time &&
+           b.zone === booking.zone &&
            b.status === 'confirmed'
     );
     

--- a/src/core/types/errors.ts
+++ b/src/core/types/errors.ts
@@ -1,5 +1,12 @@
 import { ZoneType, ZONE_CONFIG } from './index';
 
+export class BookingValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BookingValidationError';
+  }
+}
+
 export class BookingCapacityError extends Error {
   constructor(
     public zone: ZoneType,

--- a/tests/unit/core/models/BookingModel.test.ts
+++ b/tests/unit/core/models/BookingModel.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { BookingModel } from '@/core/models/BookingModel'
 import { IDataService } from '@/core/repositories'
 import { Booking, Trainer, ZoneType } from '@/core/types'
-import { BookingCapacityError } from '@/core/types/errors'
+import { BookingCapacityError, BookingValidationError } from '@/core/types/errors'
 
 // Mock del data service
 const mockTrainerRepository = {
@@ -105,6 +105,12 @@ describe('BookingModel', () => {
       await expect(bookingModel.createBooking(invalidBooking)).rejects.toThrow('El cliente es requerido')
     })
 
+    it('should throw BookingValidationError for missing client', async () => {
+      const invalidBooking = { ...validBookingData, clientId: '' }
+
+      await expect(bookingModel.createBooking(invalidBooking)).rejects.toThrow(BookingValidationError)
+    })
+
     it('should throw error for duration less than 30 minutes', async () => {
       const invalidBooking = { ...validBookingData, duration: 29 }
 
@@ -121,6 +127,12 @@ describe('BookingModel', () => {
       const invalidBooking = { ...validBookingData, date: new Date(Date.now() - 24 * 60 * 60 * 1000) } // Yesterday
 
       await expect(bookingModel.createBooking(invalidBooking)).rejects.toThrow('No se pueden hacer reservas en el pasado')
+    })
+
+    it('should throw BookingValidationError for past date', async () => {
+      const invalidBooking = { ...validBookingData, date: new Date(Date.now() - 24 * 60 * 60 * 1000) } // Yesterday
+
+      await expect(bookingModel.createBooking(invalidBooking)).rejects.toThrow(BookingValidationError)
     })
 
     it('should throw error for unavailable time slot', async () => {
@@ -155,6 +167,61 @@ describe('BookingModel', () => {
       const gabineteBooking = { ...validBookingData, zone: 'gabinete' as ZoneType }
 
       await expect(bookingModel.createBooking(gabineteBooking)).rejects.toThrow(BookingCapacityError)
+    })
+
+    it('should throw BookingCapacityError only when the correct zone is full', async () => {
+      mockTrainerRepository.getById.mockResolvedValue(mockTrainer)
+      mockTrainerRepository.getSchedule.mockResolvedValue(null)
+
+      // Fill gym zone (maxCapacity = 10)
+      const gymBookings: Booking[] = Array.from({ length: 10 }, (_, i): Booking => ({
+        id: `booking${i}`,
+        clientId: `client${i}`,
+        trainerId: 'trainer1',
+        trainerName: 'Entrenador John',
+        date: validBookingData.date,
+        time: '09:00',
+        duration: 60,
+        zone: 'gym',
+        status: 'confirmed'
+      }))
+
+      // First call (checkAvailability): no bookings so slot is available
+      mockBookingRepository.getByDate.mockResolvedValueOnce([])
+      // Second call (validateCapacity): gym is full
+      mockBookingRepository.getByDate.mockResolvedValue(gymBookings)
+
+      await expect(bookingModel.createBooking(validBookingData)).rejects.toThrow(BookingCapacityError)
+    })
+
+    it('should not throw BookingCapacityError when only a different zone is full', async () => {
+      mockTrainerRepository.getById.mockResolvedValue(mockTrainer)
+      mockTrainerRepository.getSchedule.mockResolvedValue(null)
+      mockBookingRepository.save.mockResolvedValue(undefined)
+
+      // Fill gym zone (maxCapacity = 10) but leave gabinete empty
+      const gymBookings: Booking[] = Array.from({ length: 10 }, (_, i): Booking => ({
+        id: `booking${i}`,
+        clientId: `client${i}`,
+        trainerId: 'trainer1',
+        trainerName: 'Entrenador John',
+        date: validBookingData.date,
+        time: '09:00',
+        duration: 60,
+        zone: 'gym',
+        status: 'confirmed'
+      }))
+
+      // First call (checkAvailability): no bookings so slot is available
+      mockBookingRepository.getByDate.mockResolvedValueOnce([])
+      // Second call (validateCapacity): gym is full but gabinete has none
+      mockBookingRepository.getByDate.mockResolvedValue(gymBookings)
+
+      // Booking gabinete should succeed — gym is full but gabinete is not
+      const gabineteBooking = { ...validBookingData, zone: 'gabinete' as ZoneType }
+      const result = await bookingModel.createBooking(gabineteBooking)
+
+      expect(result).toMatchObject(gabineteBooking)
     })
   })
 


### PR DESCRIPTION
Fixes #91

## Cambios

- Fix `validateCapacity`: agrega filtro `b.zone === booking.zone` para evitar que se cuenten reservas de otras zonas al validar capacidad
- Nueva clase `BookingValidationError` en `src/core/types/errors.ts`
- `validateBooking()`: reemplaza `Error` plano con `BookingValidationError` en todos los throws
- 4 tests unitarios nuevos cubriendo los bugs corregidos

Generated with [Claude Code](https://claude.ai/code)