### PR TITLE
refactor: extract AVAILABLE_TIME_SLOTS constant and remove dead code

### DIFF
--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -1,3 +1,12 @@
+export const AVAILABLE_TIME_SLOTS = [
+  '06:00', '06:30', '07:00', '07:30', '08:00', '08:30',
+  '09:00', '09:30', '10:00', '10:30', '11:00', '11:30',
+  '12:00', '12:30', '13:00', '13:30', '14:00', '14:30',
+  '15:00', '15:30', '16:00', '16:30', '17:00', '17:30',
+  '18:00', '18:30', '19:00', '19:30', '20:00', '20:30',
+  '21:00', '21:30',
+] as const;
+
 // Interfaces base del dominio
 export interface Client {
   id: string;
@@ -51,6 +60,7 @@ export interface Booking {
   time: string;
   duration: number; // minutos
   zone: ZoneType;
+  // TODO: 'pending' is never assigned — bookings are always created as 'confirmed'. Keep for future pre-confirmation flow.
   status: 'confirmed' | 'cancelled' | 'pending';
 }
 
@@ -79,12 +89,6 @@ export interface TimeSlotWithCapacity {
   bookings: Booking[];
 }
 
-export interface AppState {
-  trainers: Trainer[];
-  bookings: Booking[];
-  trainerSchedules: TrainerSchedule[];
-}
-
 export interface Program {
   id: string;
   name: string;
@@ -95,6 +99,7 @@ export interface Program {
   endDate: Date;
   totalSessions: number;
   usedSessions: number;
+  // TODO: 'inactive' is never assigned — programs transition from 'active' to 'expired' only. Keep for future manual deactivation feature.
   status: 'active' | 'inactive' | 'expired';
   previousProgramId?: string; // Referencia al programa anterior en caso de renovación
 }

--- a/src/core/view-models/TrainerViewModel.ts
+++ b/src/core/view-models/TrainerViewModel.ts
@@ -1,6 +1,6 @@
 import { makeAutoObservable, runInAction } from 'mobx';
 import { BookingModel } from '../models/BookingModel';
-import { Booking, Trainer, ZoneType, DaySchedule, TrainerSchedule } from '../types';
+import { Booking, Trainer, ZoneType, DaySchedule, TrainerSchedule, AVAILABLE_TIME_SLOTS } from '../types';
 import { BookingCapacityError } from '../types/errors';
 import { isSameDay } from 'date-fns';
 
@@ -161,17 +161,10 @@ export class TrainerViewModel {
     };
 
     // Generar horario por defecto para cada día laborable (Lunes a Sábado)
-    const allSlots = [
-      '06:00', '06:30', '07:00', '07:30', '08:00', '08:30', '09:00', '09:30',
-      '10:00', '10:30', '11:00', '11:30', '12:00', '12:30', '13:00', '13:30',
-      '14:00', '14:30', '15:00', '15:30', '16:00', '16:30', '17:00', '17:30',
-      '18:00', '18:30', '19:00', '19:30', '20:00', '20:30', '21:00', '21:30'
-    ];
-
     for (let dayIndex = 0; dayIndex < 6; dayIndex++) {
       defaultSchedule.weeklySchedule[dayIndex] = {
         day: this.getDayName(dayIndex),
-        slots: allSlots.map(time => ({ time, available: true }))
+        slots: [...AVAILABLE_TIME_SLOTS].map(time => ({ time, available: true }))
       };
     }
 
@@ -180,13 +173,7 @@ export class TrainerViewModel {
 
   // Métodos para validación
   isTimeSlotValid(time: string): boolean {
-    const allSlots = [
-      '06:00', '06:30', '07:00', '07:30', '08:00', '08:30', '09:00', '09:30',
-      '10:00', '10:30', '11:00', '11:30', '12:00', '12:30', '13:00', '13:30',
-      '14:00', '14:30', '15:00', '15:30', '16:00', '16:30', '17:00', '17:30',
-      '18:00', '18:30', '19:00', '19:30', '20:00', '20:30', '21:00', '21:30'
-    ];
-    return allSlots.includes(time);
+    return (AVAILABLE_TIME_SLOTS as readonly string[]).includes(time);
   }
 
   hasBookingsAtTime(time: string): boolean {


### PR DESCRIPTION
Implementa issue #92:

- Extrae `AVAILABLE_TIME_SLOTS` como constante exportada en `src/core/types/index.ts`
- Actualiza `TrainerViewModel` para usar la constante (elimina arrays duplicados)
- Elimina interfaz `AppState` no utilizada
- Añade TODO comments en estados muertos (`pending`, `inactive`)

Closes #92

Generated with [Claude Code](https://claude.ai/code)