### PR TITLE
feat: implementar TrainerModel y fix persistencia de horarios (#93)

### DIFF
--- a/src/components/trainer/TrainerSchedule.tsx
+++ b/src/components/trainer/TrainerSchedule.tsx
@@ -1,18 +1,11 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { observer } from 'mobx-react-lite';
 import SaveScheduleModal from './SaveScheduleModal';
 import ScheduleSavedModal from './ScheduleSavedModal';
-
-interface TimeSlot {
-  time: string;
-  available: boolean;
-}
-
-interface DaySchedule {
-  day: string;
-  slots: TimeSlot[];
-}
+import { useTrainerViewModel } from '@/core/providers/ViewModelProvider';
+import { DaySchedule, TrainerSchedule } from '@/core/types';
 
 const timeSlots = [
   '06:00', '07:00', '08:00', '09:00', '10:00', '11:00', '12:00',
@@ -23,40 +16,69 @@ const daysOfWeek = [
   'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'
 ];
 
-// Horarios específicos por día
 const getTimeSlotsForDay = (dayIndex: number) => {
-  if (dayIndex === 5) { // Sábado (índice 5)
-    return timeSlots.slice(0, 8); // De 06:00 a 13:00 (último horario 12:00)
+  if (dayIndex === 5) {
+    return timeSlots.slice(0, 8);
   }
-  return timeSlots.slice(0, 15); // Lunes a Viernes: De 06:00 a 20:00 (último horario 8pm)
+  return timeSlots.slice(0, 15);
 };
 
-export default function TrainerSchedule() {
-  const [schedule, setSchedule] = useState<DaySchedule[]>(
-    daysOfWeek.map((day, dayIndex) => ({
-      day,
-      slots: getTimeSlotsForDay(dayIndex).map(time => ({
-        time,
-        available: false
-      }))
-    }))
-  );
+const buildDefaultSchedule = (): DaySchedule[] =>
+  daysOfWeek.map((day, dayIndex) => ({
+    day,
+    slots: getTimeSlotsForDay(dayIndex).map(time => ({ time, available: false }))
+  }));
 
-  const [trainerInfo, setTrainerInfo] = useState({
-    name: 'Diego Lamas',
-    specialization: ''
-  });
+const TrainerScheduleComponent = observer(function TrainerSchedule() {
+  const vm = useTrainerViewModel();
+  const currentSchedule = vm.currentSchedule;
 
+  const [schedule, setSchedule] = useState<DaySchedule[]>(buildDefaultSchedule);
+  const [trainerName, setTrainerName] = useState('Diego Lamas');
   const [showSaveModal, setShowSaveModal] = useState(false);
   const [showSuccessModal, setShowSuccessModal] = useState(false);
 
+  useEffect(() => {
+    vm.loadTrainers();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Set trainer in ViewModel when trainers list loads or trainer name changes
+  useEffect(() => {
+    if (vm.trainers.length > 0 && trainerName) {
+      const trainer = vm.trainers.find(t => t.name === trainerName);
+      if (trainer && vm.selectedTrainerId !== trainer.id) {
+        vm.setSelectedTrainer(trainer.id);
+      }
+    }
+  }, [vm.trainers.length, trainerName]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Populate local schedule when the VM loads one from persistence
+  useEffect(() => {
+    if (currentSchedule) {
+      const slotsByDay: DaySchedule[] = daysOfWeek.map((day, dayIndex) => {
+        const storedDay = currentSchedule.weeklySchedule[dayIndex];
+        const slotMap = storedDay
+          ? Object.fromEntries(storedDay.slots.map(s => [s.time, s.available]))
+          : {};
+        return {
+          day,
+          slots: getTimeSlotsForDay(dayIndex).map(time => ({
+            time,
+            available: slotMap[time] ?? false
+          }))
+        };
+      });
+      setSchedule(slotsByDay);
+    }
+  }, [currentSchedule]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const handleSlotToggle = (dayIndex: number, slotIndex: number) => {
-    setSchedule(prev => prev.map((day, dIndex) => 
-      dIndex === dayIndex 
+    setSchedule(prev => prev.map((day, dIndex) =>
+      dIndex === dayIndex
         ? {
             ...day,
-            slots: day.slots.map((slot, sIndex) => 
-              sIndex === slotIndex 
+            slots: day.slots.map((slot, sIndex) =>
+              sIndex === slotIndex
                 ? { ...slot, available: !slot.available }
                 : slot
             )
@@ -67,9 +89,8 @@ export default function TrainerSchedule() {
 
   const handleSelectAllDay = (dayIndex: number) => {
     const allSelected = schedule[dayIndex].slots.every(slot => slot.available);
-    
-    setSchedule(prev => prev.map((day, dIndex) => 
-      dIndex === dayIndex 
+    setSchedule(prev => prev.map((day, dIndex) =>
+      dIndex === dayIndex
         ? {
             ...day,
             slots: day.slots.map(slot => ({ ...slot, available: !allSelected }))
@@ -82,11 +103,24 @@ export default function TrainerSchedule() {
     setShowSaveModal(true);
   };
 
-  const handleConfirmSave = () => {
-    // Here you would save to a backend or local storage
-    console.log('Saving schedule:', { trainerInfo, schedule });
+  const handleConfirmSave = async () => {
+    const trainer = vm.trainers.find(t => t.name === trainerName);
+    if (!trainer) {
+      setShowSaveModal(false);
+      return;
+    }
+
+    const scheduleData: TrainerSchedule = {
+      trainerId: trainer.id,
+      trainerName: trainer.name,
+      weeklySchedule: schedule
+    };
+
+    const success = await vm.saveSchedule(scheduleData);
     setShowSaveModal(false);
-    setShowSuccessModal(true);
+    if (success) {
+      setShowSuccessModal(true);
+    }
   };
 
   const handleCancelSave = () => {
@@ -98,10 +132,14 @@ export default function TrainerSchedule() {
   };
 
   const getTotalAvailableSlots = () => {
-    return schedule.reduce((total, day) => 
+    return schedule.reduce((total, day) =>
       total + day.slots.filter(slot => slot.available).length, 0
     );
   };
+
+  const trainersToDisplay = vm.trainers.length > 0
+    ? vm.trainers
+    : [{ id: '', name: 'Diego Lamas' }, { id: '', name: 'Jeanpierre Casas' }];
 
   return (
     <div className="space-y-6">
@@ -114,13 +152,14 @@ export default function TrainerSchedule() {
               Entrenador
             </label>
             <select
-              value={trainerInfo.name}
-              onChange={(e) => setTrainerInfo(prev => ({ ...prev, name: e.target.value }))}
+              value={trainerName}
+              onChange={(e) => setTrainerName(e.target.value)}
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               <option value="">Selecciona un entrenador</option>
-              <option value="Diego Lamas">Diego Lamas</option>
-              <option value="Jeanpierre Casas">Jeanpierre Casas</option>
+              {trainersToDisplay.map(t => (
+                <option key={t.id || t.name} value={t.name}>{t.name}</option>
+              ))}
             </select>
           </div>
         </div>
@@ -164,7 +203,7 @@ export default function TrainerSchedule() {
                 const daySlots = getTimeSlotsForDay(dayIndex);
                 const slot = schedule[dayIndex].slots[timeIndex];
                 const isTimeAvailable = timeIndex < daySlots.length;
-                
+
                 return (
                   <div key={`${day}-${time}`} className="p-2 text-center">
                     {isTimeAvailable ? (
@@ -212,9 +251,9 @@ export default function TrainerSchedule() {
         </div>
         <button
           onClick={handleSaveSchedule}
-          disabled={!trainerInfo.name || getTotalAvailableSlots() === 0}
+          disabled={!trainerName || getTotalAvailableSlots() === 0}
           className={`px-6 py-3 rounded-lg font-semibold transition-colors ${
-            trainerInfo.name && getTotalAvailableSlots() > 0
+            trainerName && getTotalAvailableSlots() > 0
               ? 'bg-blue-600 text-white hover:bg-blue-700'
               : 'bg-gray-300 text-gray-500 cursor-not-allowed'
           }`}
@@ -226,8 +265,8 @@ export default function TrainerSchedule() {
       {/* Save Confirmation Modal */}
       <SaveScheduleModal
         isOpen={showSaveModal}
-        trainerName={trainerInfo.name}
-        specialization={trainerInfo.specialization}
+        trainerName={trainerName}
+        specialization=""
         totalHours={getTotalAvailableSlots()}
         onConfirm={handleConfirmSave}
         onCancel={handleCancelSave}
@@ -236,11 +275,13 @@ export default function TrainerSchedule() {
       {/* Success Modal */}
       <ScheduleSavedModal
         isOpen={showSuccessModal}
-        trainerName={trainerInfo.name}
-        specialization={trainerInfo.specialization}
+        trainerName={trainerName}
+        specialization=""
         totalHours={getTotalAvailableSlots()}
         onClose={handleCloseSuccess}
       />
     </div>
   );
-}
+});
+
+export default TrainerScheduleComponent;

--- a/src/components/trainer/TrainerSchedule.tsx
+++ b/src/components/trainer/TrainerSchedule.tsx
@@ -70,7 +70,7 @@ const TrainerScheduleComponent = observer(function TrainerSchedule() {
       });
       setSchedule(slotsByDay);
     }
-  }, [currentSchedule]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [currentSchedule]);
 
   const handleSlotToggle = (dayIndex: number, slotIndex: number) => {
     setSchedule(prev => prev.map((day, dIndex) =>

--- a/src/core/models/TrainerModel.ts
+++ b/src/core/models/TrainerModel.ts
@@ -1,0 +1,59 @@
+import { TrainerSchedule, AVAILABLE_TIME_SLOTS } from '../types';
+import { IDataService } from '../repositories';
+import { TrainerValidationError } from '../types/errors';
+
+export class TrainerModel {
+  constructor(private dataService: IDataService) {}
+
+  async saveSchedule(trainerId: string, schedule: TrainerSchedule): Promise<void> {
+    this.validateSchedule(schedule);
+    await this.dataService.trainers.saveSchedule(schedule);
+  }
+
+  async getSchedule(trainerId: string): Promise<TrainerSchedule | null> {
+    return this.dataService.trainers.getSchedule(trainerId);
+  }
+
+  generateDefaultSchedule(trainerId: string, trainerName: string): TrainerSchedule {
+    const days = ['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'];
+    return {
+      trainerId,
+      trainerName,
+      weeklySchedule: days.map(day => ({
+        day,
+        slots: [...AVAILABLE_TIME_SLOTS].map(time => ({ time, available: true }))
+      }))
+    };
+  }
+
+  isTimeSlotValid(time: string): boolean {
+    return (AVAILABLE_TIME_SLOTS as readonly string[]).includes(time);
+  }
+
+  async cancelBooking(bookingId: string): Promise<void> {
+    const booking = await this.dataService.bookings.getById(bookingId);
+    if (!booking) {
+      throw new TrainerValidationError('bookingId', `La reserva '${bookingId}' no existe`);
+    }
+    await this.dataService.bookings.update(bookingId, { status: 'cancelled' });
+  }
+
+  private validateSchedule(schedule: TrainerSchedule): void {
+    if (!schedule.trainerId?.trim()) {
+      throw new TrainerValidationError('trainerId', 'El ID del entrenador es requerido');
+    }
+    if (!schedule.trainerName?.trim()) {
+      throw new TrainerValidationError('trainerName', 'El nombre del entrenador es requerido');
+    }
+    if (!schedule.weeklySchedule || schedule.weeklySchedule.length === 0) {
+      throw new TrainerValidationError('weeklySchedule', 'El horario semanal no puede estar vacío');
+    }
+    for (const day of schedule.weeklySchedule) {
+      for (const slot of day.slots) {
+        if (!this.isTimeSlotValid(slot.time)) {
+          throw new TrainerValidationError('time', `El horario '${slot.time}' no es válido`);
+        }
+      }
+    }
+  }
+}

--- a/src/core/providers/ViewModelProvider.tsx
+++ b/src/core/providers/ViewModelProvider.tsx
@@ -5,11 +5,14 @@ import { BookingViewModel } from '../view-models/BookingViewModel';
 import { BookingModel } from '../models/BookingModel';
 import { ProgramViewModel } from '../view-models/ProgramViewModel';
 import { ProgramModel } from '../models/ProgramModel';
+import { TrainerViewModel } from '../view-models/TrainerViewModel';
+import { TrainerModel } from '../models/TrainerModel';
 import { useData } from './DataProvider';
 
 interface ViewModelContextType {
   bookingVM: BookingViewModel;
   programVM: ProgramViewModel;
+  trainerVM: TrainerViewModel;
 }
 
 const ViewModelContext = createContext<ViewModelContextType | null>(null);
@@ -24,13 +27,16 @@ export function ViewModelProvider({ children }: ViewModelProviderProps) {
   const viewModels = useMemo(() => {
     const bookingModel = new BookingModel(service);
     const programModel = new ProgramModel(service);
-    const bookingVM = new BookingViewModel(bookingModel, programModel);
+    const trainerModel = new TrainerModel(service);
 
+    const bookingVM = new BookingViewModel(bookingModel, programModel);
     const programVM = new ProgramViewModel(programModel);
+    const trainerVM = new TrainerViewModel(bookingModel, trainerModel);
 
     return {
       bookingVM,
-      programVM
+      programVM,
+      trainerVM
     };
   }, [service]);
 
@@ -49,14 +55,17 @@ export function useViewModels(): ViewModelContextType {
   return context;
 }
 
-// Hook específico para booking
 export function useBookingViewModel() {
   const { bookingVM } = useViewModels();
   return bookingVM;
 }
 
-// Hook específico para programa
 export function useProgramViewModel() {
   const { programVM } = useViewModels();
   return programVM;
+}
+
+export function useTrainerViewModel() {
+  const { trainerVM } = useViewModels();
+  return trainerVM;
 }

--- a/src/core/types/errors.ts
+++ b/src/core/types/errors.ts
@@ -58,3 +58,13 @@ export class InvalidSessionCountError extends Error {
     this.name = 'InvalidSessionCountError';
   }
 }
+
+export class TrainerValidationError extends Error {
+  constructor(
+    public field: string,
+    message: string
+  ) {
+    super(message);
+    this.name = 'TrainerValidationError';
+  }
+}

--- a/src/core/view-models/TrainerViewModel.ts
+++ b/src/core/view-models/TrainerViewModel.ts
@@ -1,28 +1,30 @@
 import { makeAutoObservable, runInAction } from 'mobx';
 import { BookingModel } from '../models/BookingModel';
-import { Booking, Trainer, ZoneType, DaySchedule, TrainerSchedule, AVAILABLE_TIME_SLOTS } from '../types';
-import { BookingCapacityError } from '../types/errors';
-import { isSameDay } from 'date-fns';
+import { TrainerModel } from '../models/TrainerModel';
+import { Booking, Trainer, ZoneType, DaySchedule, TrainerSchedule } from '../types';
 
 export class TrainerViewModel {
   trainers: Trainer[] = [];
   bookings: Booking[] = [];
+  currentSchedule: TrainerSchedule | null = null;
   isLoading = false;
   error: string | null = null;
-  
+
   selectedDate: Date = new Date();
   selectedTrainerId: string | null = null;
   selectedDayIndex: number = new Date().getDay() === 0 ? -1 : new Date().getDay() - 1;
 
-  constructor(private model: BookingModel) {
+  constructor(
+    private bookingModel: BookingModel,
+    private trainerModel: TrainerModel
+  ) {
     makeAutoObservable(this);
   }
 
-  // Acciones para trainers
-  async loadTrainers() {
+  async loadTrainers(): Promise<void> {
     this.setLoading(true);
     try {
-      const trainers = await this.model.getTrainers();
+      const trainers = await this.bookingModel.getTrainers();
       runInAction(() => {
         this.trainers = trainers;
         this.error = null;
@@ -36,10 +38,10 @@ export class TrainerViewModel {
     }
   }
 
-  async loadBookings(date: Date) {
+  async loadBookings(date: Date): Promise<void> {
     this.setLoading(true);
     try {
-      const bookings = await this.model.getBookingsByDate(date);
+      const bookings = await this.bookingModel.getBookingsByDate(date);
       runInAction(() => {
         this.bookings = bookings;
         this.error = null;
@@ -53,17 +55,30 @@ export class TrainerViewModel {
     }
   }
 
-  // Acciones de configuración de horarios
-  async saveSchedule(scheduleData: TrainerSchedule): Promise<boolean> {
+  async loadSchedule(trainerId: string): Promise<void> {
+    this.setLoading(true);
     try {
-      // Aquí iría la lógica para guardar el horario en el backend
-      // Por ahora simulamos éxito
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
+      const schedule = await this.trainerModel.getSchedule(trainerId);
       runInAction(() => {
+        this.currentSchedule = schedule;
         this.error = null;
       });
-      
+    } catch (err) {
+      runInAction(() => {
+        this.error = err instanceof Error ? err.message : 'Error cargando horario';
+      });
+    } finally {
+      this.setLoading(false);
+    }
+  }
+
+  async saveSchedule(scheduleData: TrainerSchedule): Promise<boolean> {
+    try {
+      await this.trainerModel.saveSchedule(scheduleData.trainerId, scheduleData);
+      runInAction(() => {
+        this.currentSchedule = scheduleData;
+        this.error = null;
+      });
       return true;
     } catch (err) {
       runInAction(() => {
@@ -73,25 +88,21 @@ export class TrainerViewModel {
     }
   }
 
-  // Métodos unificados para obtener capacidades (reutilizados de BookingViewModel)
   async getZoneOccupancy(zone: ZoneType, date: Date, time: string, trainerId?: string): Promise<number> {
-    return await this.model.getZoneOccupancy(zone, date, time, trainerId);
+    return await this.bookingModel.getZoneOccupancy(zone, date, time, trainerId);
   }
 
   async getAllZonesOccupancy(date: Date, time: string, trainerId?: string): Promise<Record<ZoneType, number>> {
-    return await this.model.getAllZonesOccupancy(date, time, trainerId);
+    return await this.bookingModel.getAllZonesOccupancy(date, time, trainerId);
   }
 
-  // Métodos de utilidad para la vista
   async deleteBooking(bookingId: string): Promise<boolean> {
     try {
-      // Aquí iría la lógica para eliminar la reserva del backend
-      // Por ahora simulamos éxito y actualizamos el estado local
+      await this.trainerModel.cancelBooking(bookingId);
       runInAction(() => {
         this.bookings = this.bookings.filter(b => b.id !== bookingId);
         this.error = null;
       });
-      
       return true;
     } catch (err) {
       runInAction(() => {
@@ -101,29 +112,25 @@ export class TrainerViewModel {
     }
   }
 
-  // Getters computed
   get selectedTrainer(): Trainer | undefined {
     return this.trainers.find(t => t.id === this.selectedTrainerId);
   }
 
   get trainerBookings(): Booking[] {
     if (!this.selectedTrainerId) return [];
-    return this.bookings.filter(booking => 
+    return this.bookings.filter(booking =>
       booking.trainerId === this.selectedTrainerId &&
       booking.status === 'confirmed'
     );
   }
 
-  get trainerSchedule(): TrainerSchedule | undefined {
-    // Aquí iría la lógica para obtener el horario del trainer del backend
-    // Por ahora retornamos undefined para usar el horario por defecto
-    return undefined;
+  get trainerSchedule(): TrainerSchedule | null {
+    return this.currentSchedule;
   }
 
   get dailySlots(): DaySchedule {
     const schedule = this.trainerSchedule;
     if (!schedule || this.selectedDayIndex === -1) {
-      // Si no hay horario configurado o es domingo, usar disponibilidad general
       const trainer = this.selectedTrainer;
       if (trainer) {
         return {
@@ -134,46 +141,33 @@ export class TrainerViewModel {
       return { day: this.getDayName(this.selectedDayIndex), slots: [] };
     }
 
-    return schedule.weeklySchedule[this.selectedDayIndex] || { 
-      day: this.getDayName(this.selectedDayIndex), 
-      slots: [] 
+    return schedule.weeklySchedule[this.selectedDayIndex] || {
+      day: this.getDayName(this.selectedDayIndex),
+      slots: []
     };
   }
 
-  // Métodos para actualizar estado
-  setSelectedDate(date: Date) {
+  setSelectedDate(date: Date): void {
     this.selectedDate = date;
-    // Actualizar el día seleccionado basado en la nueva fecha
     const dayOfWeek = date.getDay();
     this.selectedDayIndex = dayOfWeek === 0 ? -1 : dayOfWeek - 1;
     this.loadBookings(date);
   }
 
-  setSelectedTrainer(trainerId: string) {
+  setSelectedTrainer(trainerId: string): void {
     this.selectedTrainerId = trainerId;
+    this.loadSchedule(trainerId);
   }
 
   generateDefaultSchedule(): TrainerSchedule {
-    const defaultSchedule: TrainerSchedule = {
-      trainerId: this.selectedTrainerId!,
-      trainerName: `Entrenador ${this.selectedTrainer?.name || ''}`,
-      weeklySchedule: []
-    };
-
-    // Generar horario por defecto para cada día laborable (Lunes a Sábado)
-    for (let dayIndex = 0; dayIndex < 6; dayIndex++) {
-      defaultSchedule.weeklySchedule[dayIndex] = {
-        day: this.getDayName(dayIndex),
-        slots: [...AVAILABLE_TIME_SLOTS].map(time => ({ time, available: true }))
-      };
-    }
-
-    return defaultSchedule;
+    return this.trainerModel.generateDefaultSchedule(
+      this.selectedTrainerId!,
+      this.selectedTrainer?.name || ''
+    );
   }
 
-  // Métodos para validación
   isTimeSlotValid(time: string): boolean {
-    return (AVAILABLE_TIME_SLOTS as readonly string[]).includes(time);
+    return this.trainerModel.isTimeSlotValid(time);
   }
 
   hasBookingsAtTime(time: string): boolean {
@@ -190,18 +184,16 @@ export class TrainerViewModel {
     }
   }
 
-  // Método para limpiar errores
-  clearError() {
+  clearError(): void {
     this.error = null;
   }
 
-  // Método auxiliar para obtener nombre del día
   private getDayName(dayIndex: number): string {
-    const days = ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'];
+    const days = ['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'];
     return dayIndex >= 0 && dayIndex < days.length ? days[dayIndex] : 'Día no válido';
   }
 
-  private setLoading(loading: boolean) {
+  private setLoading(loading: boolean): void {
     this.isLoading = loading;
   }
 }

--- a/tests/integration/TrainerFlow.integration.test.ts
+++ b/tests/integration/TrainerFlow.integration.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Integration tests: TrainerModel ↔ LocalStorageDataService
+ *
+ * These tests exercise the full stack from Model down to the real
+ * LocalStorageDataService (backed by jsdom's localStorage), with no mocks of
+ * the persistence layer.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { LocalStorageDataService } from '@/core/repositories/localStorage';
+import { TrainerModel } from '@/core/models/TrainerModel';
+import { TrainerSchedule, AVAILABLE_TIME_SLOTS } from '@/core/types';
+import { TrainerValidationError } from '@/core/types/errors';
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+async function makeModel(): Promise<{ model: TrainerModel; service: LocalStorageDataService }> {
+  const service = new LocalStorageDataService();
+  await service.initialize();
+  const model = new TrainerModel(service);
+  return { model, service };
+}
+
+function validSchedule(overrides: Partial<TrainerSchedule> = {}): TrainerSchedule {
+  return {
+    trainerId: 'trainer1',
+    trainerName: 'Diego Lamas',
+    weeklySchedule: [
+      {
+        day: 'Lunes',
+        slots: [
+          { time: '09:00', available: true },
+          { time: '10:00', available: false }
+        ]
+      }
+    ],
+    ...overrides
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TrainerModel (integration)', () => {
+  describe('saveSchedule + getSchedule', () => {
+    it('persiste el horario y lo recupera correctamente', async () => {
+      const { model } = await makeModel();
+      const schedule = validSchedule();
+
+      await model.saveSchedule('trainer1', schedule);
+      const retrieved = await model.getSchedule('trainer1');
+
+      expect(retrieved).not.toBeNull();
+      expect(retrieved!.trainerId).toBe('trainer1');
+      expect(retrieved!.weeklySchedule[0].day).toBe('Lunes');
+      expect(retrieved!.weeklySchedule[0].slots).toHaveLength(2);
+    });
+
+    it('sobrescribe el horario anterior al guardar de nuevo', async () => {
+      const { model } = await makeModel();
+
+      await model.saveSchedule('trainer1', validSchedule());
+
+      const updated: TrainerSchedule = {
+        trainerId: 'trainer1',
+        trainerName: 'Diego Lamas',
+        weeklySchedule: [
+          { day: 'Lunes', slots: [{ time: '08:00', available: true }] },
+          { day: 'Martes', slots: [{ time: '09:00', available: true }] }
+        ]
+      };
+      await model.saveSchedule('trainer1', updated);
+
+      const retrieved = await model.getSchedule('trainer1');
+      expect(retrieved!.weeklySchedule).toHaveLength(2);
+      expect(retrieved!.weeklySchedule[0].slots[0].time).toBe('08:00');
+    });
+
+    it('retorna null si el entrenador no tiene horario guardado', async () => {
+      const { model } = await makeModel();
+
+      const result = await model.getSchedule('trainer_no_schedule');
+
+      expect(result).toBeNull();
+    });
+
+    it('horarios de dos entrenadores se guardan independientemente', async () => {
+      const { model } = await makeModel();
+
+      const schedule1 = validSchedule({ trainerId: 'trainer1' });
+      const schedule2: TrainerSchedule = {
+        trainerId: 'trainer2',
+        trainerName: 'Jeanpierre Casas',
+        weeklySchedule: [
+          { day: 'Martes', slots: [{ time: '15:00', available: true }] }
+        ]
+      };
+
+      await model.saveSchedule('trainer1', schedule1);
+      await model.saveSchedule('trainer2', schedule2);
+
+      const r1 = await model.getSchedule('trainer1');
+      const r2 = await model.getSchedule('trainer2');
+
+      expect(r1!.trainerId).toBe('trainer1');
+      expect(r2!.trainerId).toBe('trainer2');
+      expect(r2!.weeklySchedule[0].day).toBe('Martes');
+    });
+  });
+
+  describe('generateDefaultSchedule', () => {
+    it('genera horario con datos correctos y persiste correctamente', async () => {
+      const { model } = await makeModel();
+
+      const schedule = model.generateDefaultSchedule('trainer1', 'Diego Lamas');
+      await model.saveSchedule('trainer1', schedule);
+
+      const retrieved = await model.getSchedule('trainer1');
+      expect(retrieved!.weeklySchedule).toHaveLength(6);
+      expect(retrieved!.weeklySchedule[0].slots).toHaveLength(AVAILABLE_TIME_SLOTS.length);
+    });
+  });
+
+  describe('cancelBooking', () => {
+    it('cambia el estado de la reserva a cancelled', async () => {
+      const { model, service } = await makeModel();
+
+      const bookings = await service.bookings.getAll();
+      const confirmed = bookings.find(b => b.status === 'confirmed');
+      expect(confirmed).toBeDefined();
+
+      await model.cancelBooking(confirmed!.id);
+
+      const updated = await service.bookings.getById(confirmed!.id);
+      expect(updated!.status).toBe('cancelled');
+    });
+
+    it('lanza TrainerValidationError para una reserva inexistente', async () => {
+      const { model } = await makeModel();
+
+      await expect(model.cancelBooking('booking_nonexistent'))
+        .rejects.toThrow(TrainerValidationError);
+    });
+
+    it('no afecta otras reservas al cancelar una', async () => {
+      const { model, service } = await makeModel();
+
+      const allBefore = await service.bookings.getAll();
+      const confirmedBefore = allBefore.filter(b => b.status === 'confirmed');
+      expect(confirmedBefore.length).toBeGreaterThan(1);
+
+      await model.cancelBooking(confirmedBefore[0].id);
+
+      const allAfter = await service.bookings.getAll();
+      const cancelledAfter = allAfter.filter(b => b.status === 'cancelled');
+
+      // Only one more cancellation
+      const cancelledBefore = allBefore.filter(b => b.status === 'cancelled');
+      expect(cancelledAfter.length).toBe(cancelledBefore.length + 1);
+    });
+  });
+
+  describe('saveSchedule validations', () => {
+    it('rechaza schedule con trainerId vacío', async () => {
+      const { model } = await makeModel();
+
+      await expect(
+        model.saveSchedule('', validSchedule({ trainerId: '' }))
+      ).rejects.toThrow(TrainerValidationError);
+    });
+
+    it('rechaza schedule con weeklySchedule vacío', async () => {
+      const { model } = await makeModel();
+
+      await expect(
+        model.saveSchedule('trainer1', validSchedule({ weeklySchedule: [] }))
+      ).rejects.toThrow(TrainerValidationError);
+    });
+  });
+});

--- a/tests/unit/core/models/TrainerModel.test.ts
+++ b/tests/unit/core/models/TrainerModel.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TrainerModel } from '@/core/models/TrainerModel';
+import { IDataService } from '@/core/repositories';
+import { TrainerSchedule, AVAILABLE_TIME_SLOTS } from '@/core/types';
+import { TrainerValidationError } from '@/core/types/errors';
+
+const mockTrainerRepository = {
+  getAll: vi.fn(),
+  getById: vi.fn(),
+  save: vi.fn(),
+  saveSchedule: vi.fn(),
+  getSchedule: vi.fn()
+};
+
+const mockBookingRepository = {
+  getAll: vi.fn(),
+  getById: vi.fn(),
+  getByDate: vi.fn(),
+  getByTrainer: vi.fn(),
+  save: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn()
+};
+
+const mockDataService: IDataService = {
+  clients: {
+    getAll: vi.fn(),
+    getById: vi.fn(),
+    getByEmail: vi.fn(),
+    save: vi.fn(),
+    delete: vi.fn()
+  },
+  trainers: mockTrainerRepository,
+  bookings: mockBookingRepository,
+  programs: {
+    getAll: vi.fn(),
+    getById: vi.fn(),
+    getByTrainer: vi.fn(),
+    getByClient: vi.fn(),
+    save: vi.fn(),
+    delete: vi.fn()
+  },
+  initialize: vi.fn(),
+  clear: vi.fn()
+};
+
+describe('TrainerModel', () => {
+  let trainerModel: TrainerModel;
+
+  beforeEach(() => {
+    trainerModel = new TrainerModel(mockDataService);
+    vi.clearAllMocks();
+  });
+
+  describe('generateDefaultSchedule', () => {
+    it('retorna horario con 6 días laborables', () => {
+      const schedule = trainerModel.generateDefaultSchedule('trainer1', 'Diego Lamas');
+
+      expect(schedule.weeklySchedule).toHaveLength(6);
+    });
+
+    it('los días son lunes a sábado en orden correcto', () => {
+      const schedule = trainerModel.generateDefaultSchedule('trainer1', 'Diego Lamas');
+      const days = schedule.weeklySchedule.map(d => d.day);
+
+      expect(days).toEqual(['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado']);
+    });
+
+    it('todos los slots están disponibles por defecto', () => {
+      const schedule = trainerModel.generateDefaultSchedule('trainer1', 'Diego Lamas');
+
+      for (const day of schedule.weeklySchedule) {
+        expect(day.slots.every(s => s.available)).toBe(true);
+      }
+    });
+
+    it('cada día tiene todos los AVAILABLE_TIME_SLOTS', () => {
+      const schedule = trainerModel.generateDefaultSchedule('trainer1', 'Diego Lamas');
+
+      for (const day of schedule.weeklySchedule) {
+        expect(day.slots).toHaveLength(AVAILABLE_TIME_SLOTS.length);
+        expect(day.slots.map(s => s.time)).toEqual([...AVAILABLE_TIME_SLOTS]);
+      }
+    });
+
+    it('asigna trainerId y trainerName correctamente', () => {
+      const schedule = trainerModel.generateDefaultSchedule('trainer1', 'Diego Lamas');
+
+      expect(schedule.trainerId).toBe('trainer1');
+      expect(schedule.trainerName).toBe('Diego Lamas');
+    });
+  });
+
+  describe('isTimeSlotValid', () => {
+    it('retorna true para un slot válido', () => {
+      expect(trainerModel.isTimeSlotValid('09:00')).toBe(true);
+      expect(trainerModel.isTimeSlotValid('06:00')).toBe(true);
+      expect(trainerModel.isTimeSlotValid('21:30')).toBe(true);
+    });
+
+    it('retorna false para un slot inválido', () => {
+      expect(trainerModel.isTimeSlotValid('09:15')).toBe(false);
+      expect(trainerModel.isTimeSlotValid('25:00')).toBe(false);
+      expect(trainerModel.isTimeSlotValid('')).toBe(false);
+      expect(trainerModel.isTimeSlotValid('22:00')).toBe(false);
+    });
+
+    it('valida todos los slots de AVAILABLE_TIME_SLOTS', () => {
+      for (const slot of AVAILABLE_TIME_SLOTS) {
+        expect(trainerModel.isTimeSlotValid(slot)).toBe(true);
+      }
+    });
+  });
+
+  describe('saveSchedule', () => {
+    const validSchedule: TrainerSchedule = {
+      trainerId: 'trainer1',
+      trainerName: 'Diego Lamas',
+      weeklySchedule: [
+        {
+          day: 'Lunes',
+          slots: [{ time: '09:00', available: true }]
+        }
+      ]
+    };
+
+    it('persiste el horario en el repositorio', async () => {
+      mockTrainerRepository.saveSchedule.mockResolvedValue(undefined);
+
+      await trainerModel.saveSchedule('trainer1', validSchedule);
+
+      expect(mockTrainerRepository.saveSchedule).toHaveBeenCalledOnce();
+      expect(mockTrainerRepository.saveSchedule).toHaveBeenCalledWith(validSchedule);
+    });
+
+    it('lanza TrainerValidationError si trainerId está vacío', async () => {
+      const invalid = { ...validSchedule, trainerId: '' };
+
+      await expect(trainerModel.saveSchedule('', invalid))
+        .rejects.toThrow(TrainerValidationError);
+      expect(mockTrainerRepository.saveSchedule).not.toHaveBeenCalled();
+    });
+
+    it('lanza TrainerValidationError si trainerName está vacío', async () => {
+      const invalid = { ...validSchedule, trainerName: '   ' };
+
+      await expect(trainerModel.saveSchedule('trainer1', invalid))
+        .rejects.toThrow(TrainerValidationError);
+      expect(mockTrainerRepository.saveSchedule).not.toHaveBeenCalled();
+    });
+
+    it('lanza TrainerValidationError si weeklySchedule está vacío', async () => {
+      const invalid = { ...validSchedule, weeklySchedule: [] };
+
+      await expect(trainerModel.saveSchedule('trainer1', invalid))
+        .rejects.toThrow(TrainerValidationError);
+      expect(mockTrainerRepository.saveSchedule).not.toHaveBeenCalled();
+    });
+
+    it('lanza TrainerValidationError si un slot tiene tiempo inválido', async () => {
+      const invalid: TrainerSchedule = {
+        ...validSchedule,
+        weeklySchedule: [
+          { day: 'Lunes', slots: [{ time: '09:15', available: true }] }
+        ]
+      };
+
+      await expect(trainerModel.saveSchedule('trainer1', invalid))
+        .rejects.toThrow(TrainerValidationError);
+      expect(mockTrainerRepository.saveSchedule).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getSchedule', () => {
+    it('retorna el horario del repositorio', async () => {
+      const mockSchedule: TrainerSchedule = {
+        trainerId: 'trainer1',
+        trainerName: 'Diego Lamas',
+        weeklySchedule: []
+      };
+      mockTrainerRepository.getSchedule.mockResolvedValue(mockSchedule);
+
+      const result = await trainerModel.getSchedule('trainer1');
+
+      expect(result).toEqual(mockSchedule);
+      expect(mockTrainerRepository.getSchedule).toHaveBeenCalledWith('trainer1');
+    });
+
+    it('retorna null si no hay horario guardado', async () => {
+      mockTrainerRepository.getSchedule.mockResolvedValue(null);
+
+      const result = await trainerModel.getSchedule('trainer1');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('cancelBooking', () => {
+    it('actualiza el estado del booking a cancelled', async () => {
+      const mockBooking = {
+        id: 'booking1',
+        clientId: 'client1',
+        trainerId: 'trainer1',
+        trainerName: 'Diego Lamas',
+        date: new Date(),
+        time: '09:00',
+        duration: 60,
+        zone: 'gym' as const,
+        status: 'confirmed' as const
+      };
+      mockBookingRepository.getById.mockResolvedValue(mockBooking);
+      mockBookingRepository.update.mockResolvedValue(undefined);
+
+      await trainerModel.cancelBooking('booking1');
+
+      expect(mockBookingRepository.update).toHaveBeenCalledWith('booking1', { status: 'cancelled' });
+    });
+
+    it('lanza TrainerValidationError si la reserva no existe', async () => {
+      mockBookingRepository.getById.mockResolvedValue(null);
+
+      await expect(trainerModel.cancelBooking('nonexistent'))
+        .rejects.toThrow(TrainerValidationError);
+      expect(mockBookingRepository.update).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Cierra #93

## Cambios

- Nuevo `TrainerModel` con lógica de negocio: saveSchedule, getSchedule, generateDefaultSchedule, isTimeSlotValid, cancelBooking
- Añade `TrainerValidationError` a errors.ts
- Refactoriza `TrainerViewModel`: saveSchedule y deleteBooking ahora persisten datos reales
- Actualiza ViewModelProvider con inyección de TrainerModel y hook useTrainerViewModel()
- Conecta TrainerSchedule.tsx al ViewModel: carga horario existente y persiste al guardar
- 27 nuevos tests (17 unitarios + 10 integración)

Generated with [Claude Code](https://claude.ai/code)