### PR TITLE
feat: implementar ScheduleModel y refactorizar BookingModel (fix SRP)

### DIFF
--- a/src/core/models/BookingModel.ts
+++ b/src/core/models/BookingModel.ts
@@ -1,10 +1,14 @@
 import { Booking, Trainer, ZoneType, ZONE_CONFIG } from '../types';
 import { BookingCapacityError, BookingValidationError } from '../types/errors';
 import { IDataService } from '../repositories';
+import { ScheduleModel } from './ScheduleModel';
 import { isSameDay } from 'date-fns';
 
 export class BookingModel {
-  constructor(private dataService: IDataService) {}
+  constructor(
+    private dataService: IDataService,
+    private scheduleModel: ScheduleModel
+  ) {}
 
   async createBooking(booking: Omit<Booking, 'id'>): Promise<Booking> {
     // Validaciones de negocio
@@ -39,54 +43,18 @@ export class BookingModel {
   }
 
   async getAvailableSlots(trainerId: string, date: Date): Promise<string[]> {
-    const trainer = await this.getTrainerById(trainerId);
-    if (!trainer) return [];
+    const scheduledSlots = await this.scheduleModel.getAvailableSlots(trainerId, date);
 
-    // Obtener el horario configurado del entrenador
-    const trainerSchedule = await this.dataService.trainers.getSchedule(trainerId);
-    if (!trainerSchedule) {
-      // Si no hay horario configurado, usar los slots por defecto del entrenador
-      const existingBookings = await this.getBookingsByDate(date);
-      const maxCapacity = 10;
-      
-      return trainer.availableSlots.filter(slot => {
-        const bookingsForSlot = existingBookings.filter(
-          b => b.trainerId === trainerId && 
-               b.time === slot && 
-               b.status === 'confirmed'
-        );
-        return bookingsForSlot.length < maxCapacity;
-      });
-    }
-
-    // Determinar qué día de la semana es
-    const dayOfWeek = date.getDay(); // 0 = Domingo, 1 = Lunes, ..., 6 = Sábado
-    const dayIndex = dayOfWeek === 0 ? -1 : dayOfWeek - 1; // Convertir a índice de días laborables (Lun=0, Sáb=5)
-    
-    // Si es domingo, no hay horarios disponibles
-    if (dayIndex < 0 || dayIndex > 5) {
-      return [];
-    }
-
-    const daySchedule = trainerSchedule.weeklySchedule[dayIndex];
-    if (!daySchedule) return [];
-
-    // Obtener solo los slots marcados como disponibles
-    const availableSlots = daySchedule.slots
-      .filter(slot => slot.available)
-      .map(slot => slot.time);
-
-    // Filtrar los que ya están llenos (capacidad máxima = 10)
     const existingBookings = await this.getBookingsByDate(date);
-    const maxCapacity = 10;
-    
-    return availableSlots.filter(slot => {
+    const maxCapacity = ZONE_CONFIG.gym.maxCapacity;
+
+    return scheduledSlots.filter(slot => {
       const bookingsForSlot = existingBookings.filter(
-        b => b.trainerId === trainerId && 
-             b.time === slot && 
+        b => b.trainerId === trainerId &&
+             b.time === slot &&
              b.status === 'confirmed'
       );
-      return bookingsForSlot.length < maxCapacity; // Disponible si hay menos de 10 reservas
+      return bookingsForSlot.length < maxCapacity;
     });
   }
 

--- a/src/core/models/ScheduleModel.ts
+++ b/src/core/models/ScheduleModel.ts
@@ -1,0 +1,37 @@
+import { TrainerSchedule } from '../types';
+import { IDataService } from '../repositories';
+
+export class ScheduleModel {
+  constructor(private dataService: IDataService) {}
+
+  async getTrainerSchedule(trainerId: string): Promise<TrainerSchedule | null> {
+    return this.dataService.trainers.getSchedule(trainerId);
+  }
+
+  async getAvailableSlots(trainerId: string, date: Date): Promise<string[]> {
+    const trainer = await this.dataService.trainers.getById(trainerId);
+    if (!trainer) return [];
+
+    const trainerSchedule = await this.dataService.trainers.getSchedule(trainerId);
+    if (!trainerSchedule) {
+      return [...trainer.availableSlots];
+    }
+
+    const dayOfWeek = date.getDay();
+    const dayIndex = dayOfWeek === 0 ? -1 : dayOfWeek - 1;
+
+    if (dayIndex < 0 || dayIndex > 5) return [];
+
+    const daySchedule = trainerSchedule.weeklySchedule[dayIndex];
+    if (!daySchedule) return [];
+
+    return daySchedule.slots
+      .filter(slot => slot.available)
+      .map(slot => slot.time);
+  }
+
+  async isSlotAvailable(trainerId: string, date: Date, time: string): Promise<boolean> {
+    const availableSlots = await this.getAvailableSlots(trainerId, date);
+    return availableSlots.includes(time);
+  }
+}

--- a/src/core/providers/ViewModelProvider.tsx
+++ b/src/core/providers/ViewModelProvider.tsx
@@ -7,6 +7,7 @@ import { ProgramViewModel } from '../view-models/ProgramViewModel';
 import { ProgramModel } from '../models/ProgramModel';
 import { TrainerViewModel } from '../view-models/TrainerViewModel';
 import { TrainerModel } from '../models/TrainerModel';
+import { ScheduleModel } from '../models/ScheduleModel';
 import { useData } from './DataProvider';
 
 interface ViewModelContextType {
@@ -25,13 +26,14 @@ export function ViewModelProvider({ children }: ViewModelProviderProps) {
   const { service } = useData();
 
   const viewModels = useMemo(() => {
-    const bookingModel = new BookingModel(service);
+    const scheduleModel = new ScheduleModel(service);
+    const bookingModel = new BookingModel(service, scheduleModel);
     const programModel = new ProgramModel(service);
     const trainerModel = new TrainerModel(service);
 
     const bookingVM = new BookingViewModel(bookingModel, programModel);
     const programVM = new ProgramViewModel(programModel);
-    const trainerVM = new TrainerViewModel(bookingModel, trainerModel);
+    const trainerVM = new TrainerViewModel(bookingModel, trainerModel, scheduleModel);
 
     return {
       bookingVM,

--- a/src/core/view-models/TrainerViewModel.ts
+++ b/src/core/view-models/TrainerViewModel.ts
@@ -1,6 +1,7 @@
 import { makeAutoObservable, runInAction } from 'mobx';
 import { BookingModel } from '../models/BookingModel';
 import { TrainerModel } from '../models/TrainerModel';
+import { ScheduleModel } from '../models/ScheduleModel';
 import { Booking, Trainer, ZoneType, DaySchedule, TrainerSchedule } from '../types';
 
 export class TrainerViewModel {
@@ -16,7 +17,8 @@ export class TrainerViewModel {
 
   constructor(
     private bookingModel: BookingModel,
-    private trainerModel: TrainerModel
+    private trainerModel: TrainerModel,
+    private scheduleModel: ScheduleModel
   ) {
     makeAutoObservable(this);
   }
@@ -58,7 +60,7 @@ export class TrainerViewModel {
   async loadSchedule(trainerId: string): Promise<void> {
     this.setLoading(true);
     try {
-      const schedule = await this.trainerModel.getSchedule(trainerId);
+      const schedule = await this.scheduleModel.getTrainerSchedule(trainerId);
       runInAction(() => {
         this.currentSchedule = schedule;
         this.error = null;
@@ -155,7 +157,10 @@ export class TrainerViewModel {
   }
 
   setSelectedTrainer(trainerId: string): void {
-    this.selectedTrainerId = trainerId;
+    runInAction(() => {
+      this.selectedTrainerId = trainerId;
+      this.currentSchedule = null;
+    });
     this.loadSchedule(trainerId);
   }
 

--- a/tests/unit/core/models/BookingModel.test.ts
+++ b/tests/unit/core/models/BookingModel.test.ts
@@ -63,12 +63,6 @@ describe('BookingModel', () => {
   })
 
   describe('createBooking', () => {
-    const mockTrainer: Trainer = {
-      id: 'trainer1',
-      name: 'John',
-      availableSlots: ['09:00', '10:00', '11:00']
-    }
-
     const validBookingData: Omit<Booking, 'id'> = {
       clientId: 'client1',
       trainerId: 'trainer1',

--- a/tests/unit/core/models/BookingModel.test.ts
+++ b/tests/unit/core/models/BookingModel.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { BookingModel } from '@/core/models/BookingModel'
+import { ScheduleModel } from '@/core/models/ScheduleModel'
 import { IDataService } from '@/core/repositories'
 import { Booking, Trainer, ZoneType } from '@/core/types'
 import { BookingCapacityError, BookingValidationError } from '@/core/types/errors'
@@ -47,11 +48,17 @@ const mockDataService: IDataService = {
   clear: vi.fn()
 }
 
+const mockScheduleModel = {
+  getAvailableSlots: vi.fn(),
+  isSlotAvailable: vi.fn(),
+  getTrainerSchedule: vi.fn()
+}
+
 describe('BookingModel', () => {
   let bookingModel: BookingModel
 
   beforeEach(() => {
-    bookingModel = new BookingModel(mockDataService)
+    bookingModel = new BookingModel(mockDataService, mockScheduleModel as unknown as ScheduleModel)
     vi.clearAllMocks()
   })
 
@@ -74,8 +81,7 @@ describe('BookingModel', () => {
     }
 
     it('should create a booking successfully', async () => {
-      mockTrainerRepository.getById.mockResolvedValue(mockTrainer)
-      mockTrainerRepository.getSchedule.mockResolvedValue(null)
+      mockScheduleModel.getAvailableSlots.mockResolvedValue(['09:00', '10:00', '11:00'])
       mockBookingRepository.getByDate.mockResolvedValue([])
       mockBookingRepository.save.mockResolvedValue(undefined)
 
@@ -88,8 +94,7 @@ describe('BookingModel', () => {
     })
 
     it('should not touch the program repository when creating a booking', async () => {
-      mockTrainerRepository.getById.mockResolvedValue(mockTrainer)
-      mockTrainerRepository.getSchedule.mockResolvedValue(null)
+      mockScheduleModel.getAvailableSlots.mockResolvedValue(['09:00', '10:00', '11:00'])
       mockBookingRepository.getByDate.mockResolvedValue([])
       mockBookingRepository.save.mockResolvedValue(undefined)
 
@@ -136,8 +141,7 @@ describe('BookingModel', () => {
     })
 
     it('should throw error for unavailable time slot', async () => {
-      mockTrainerRepository.getById.mockResolvedValue(mockTrainer)
-      mockTrainerRepository.getSchedule.mockResolvedValue(null)
+      mockScheduleModel.getAvailableSlots.mockResolvedValue(['09:00', '10:00', '11:00'])
       mockBookingRepository.getByDate.mockResolvedValue([])
 
       const invalidBooking = { ...validBookingData, time: '12:00' } // Not in available slots
@@ -146,8 +150,7 @@ describe('BookingModel', () => {
     })
 
     it('should throw BookingCapacityError when gabinete zone is at capacity', async () => {
-      mockTrainerRepository.getById.mockResolvedValue(mockTrainer)
-      mockTrainerRepository.getSchedule.mockResolvedValue(null)
+      mockScheduleModel.getAvailableSlots.mockResolvedValue(['09:00', '10:00', '11:00'])
 
       // Create 1 existing booking for gabinete zone (max capacity)
       const existingBookings: Booking[] = [{
@@ -161,7 +164,7 @@ describe('BookingModel', () => {
         zone: 'gabinete',
         status: 'confirmed'
       }]
-      
+
       mockBookingRepository.getByDate.mockResolvedValue(existingBookings)
 
       const gabineteBooking = { ...validBookingData, zone: 'gabinete' as ZoneType }
@@ -170,8 +173,7 @@ describe('BookingModel', () => {
     })
 
     it('should throw BookingCapacityError only when the correct zone is full', async () => {
-      mockTrainerRepository.getById.mockResolvedValue(mockTrainer)
-      mockTrainerRepository.getSchedule.mockResolvedValue(null)
+      mockScheduleModel.getAvailableSlots.mockResolvedValue(['09:00', '10:00', '11:00'])
 
       // Fill gym zone (maxCapacity = 10)
       const gymBookings: Booking[] = Array.from({ length: 10 }, (_, i): Booking => ({
@@ -186,7 +188,7 @@ describe('BookingModel', () => {
         status: 'confirmed'
       }))
 
-      // First call (checkAvailability): no bookings so slot is available
+      // First call (getAvailableSlots capacity check): no bookings so slot is available
       mockBookingRepository.getByDate.mockResolvedValueOnce([])
       // Second call (validateCapacity): gym is full
       mockBookingRepository.getByDate.mockResolvedValue(gymBookings)
@@ -195,8 +197,7 @@ describe('BookingModel', () => {
     })
 
     it('should not throw BookingCapacityError when only a different zone is full', async () => {
-      mockTrainerRepository.getById.mockResolvedValue(mockTrainer)
-      mockTrainerRepository.getSchedule.mockResolvedValue(null)
+      mockScheduleModel.getAvailableSlots.mockResolvedValue(['09:00', '10:00', '11:00'])
       mockBookingRepository.save.mockResolvedValue(undefined)
 
       // Fill gym zone (maxCapacity = 10) but leave gabinete empty
@@ -212,7 +213,7 @@ describe('BookingModel', () => {
         status: 'confirmed'
       }))
 
-      // First call (checkAvailability): no bookings so slot is available
+      // First call (getAvailableSlots capacity check): no bookings so slot is available
       mockBookingRepository.getByDate.mockResolvedValueOnce([])
       // Second call (validateCapacity): gym is full but gabinete has none
       mockBookingRepository.getByDate.mockResolvedValue(gymBookings)
@@ -294,16 +295,19 @@ describe('BookingModel', () => {
   })
 
   describe('getAvailableSlots', () => {
-    const mockTrainer: Trainer = {
-      id: 'trainer1',
-      name: 'John',
-      availableSlots: ['09:00', '10:00', '11:00']
-    }
+    it('delega al ScheduleModel para obtener los slots configurados', async () => {
+      const date = new Date('2024-01-15')
+      mockScheduleModel.getAvailableSlots.mockResolvedValue(['09:00', '10:00', '11:00'])
+      mockBookingRepository.getByDate.mockResolvedValue([])
 
-    it('should return available slots when no schedule is set', async () => {
-      const date = new Date('2024-01-15') // Monday
-      mockTrainerRepository.getById.mockResolvedValue(mockTrainer)
-      mockTrainerRepository.getSchedule.mockResolvedValue(null)
+      await bookingModel.getAvailableSlots('trainer1', date)
+
+      expect(mockScheduleModel.getAvailableSlots).toHaveBeenCalledWith('trainer1', date)
+    })
+
+    it('should return available slots when schedule has no capacity issues', async () => {
+      const date = new Date('2024-01-15')
+      mockScheduleModel.getAvailableSlots.mockResolvedValue(['09:00', '10:00', '11:00'])
       mockBookingRepository.getByDate.mockResolvedValue([])
 
       const result = await bookingModel.getAvailableSlots('trainer1', date)
@@ -311,8 +315,9 @@ describe('BookingModel', () => {
       expect(result).toEqual(['09:00', '10:00', '11:00'])
     })
 
-    it('should return empty array when trainer not found', async () => {
-      mockTrainerRepository.getById.mockResolvedValue(null)
+    it('should return empty array when ScheduleModel returns no slots', async () => {
+      mockScheduleModel.getAvailableSlots.mockResolvedValue([])
+      mockBookingRepository.getByDate.mockResolvedValue([])
 
       const result = await bookingModel.getAvailableSlots('nonexistent', new Date())
 
@@ -320,10 +325,9 @@ describe('BookingModel', () => {
     })
 
     it('should filter out slots at capacity', async () => {
-      const date = new Date('2024-01-15') // Monday
-      mockTrainerRepository.getById.mockResolvedValue(mockTrainer)
-      mockTrainerRepository.getSchedule.mockResolvedValue(null)
-      
+      const date = new Date('2024-01-15')
+      mockScheduleModel.getAvailableSlots.mockResolvedValue(['09:00', '10:00', '11:00'])
+
       // Create 10 bookings for 09:00 slot (at capacity)
       const existingBookings: Booking[] = Array.from({ length: 10 }, (_, i): Booking => ({
         id: `booking${i}`,
@@ -336,7 +340,7 @@ describe('BookingModel', () => {
         zone: 'gym',
         status: 'confirmed'
       }))
-      
+
       mockBookingRepository.getByDate.mockResolvedValue(existingBookings)
 
       const result = await bookingModel.getAvailableSlots('trainer1', date)

--- a/tests/unit/core/models/ScheduleModel.test.ts
+++ b/tests/unit/core/models/ScheduleModel.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ScheduleModel } from '@/core/models/ScheduleModel';
+import { IDataService } from '@/core/repositories';
+import { Trainer, TrainerSchedule } from '@/core/types';
+
+const mockTrainerRepository = {
+  getAll: vi.fn(),
+  getById: vi.fn(),
+  save: vi.fn(),
+  saveSchedule: vi.fn(),
+  getSchedule: vi.fn()
+};
+
+const mockDataService: IDataService = {
+  clients: {
+    getAll: vi.fn(),
+    getById: vi.fn(),
+    getByEmail: vi.fn(),
+    save: vi.fn(),
+    delete: vi.fn()
+  },
+  trainers: mockTrainerRepository,
+  bookings: {
+    getAll: vi.fn(),
+    getById: vi.fn(),
+    getByDate: vi.fn(),
+    getByTrainer: vi.fn(),
+    save: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn()
+  },
+  programs: {
+    getAll: vi.fn(),
+    getById: vi.fn(),
+    getByTrainer: vi.fn(),
+    getByClient: vi.fn(),
+    save: vi.fn(),
+    delete: vi.fn()
+  },
+  initialize: vi.fn(),
+  clear: vi.fn()
+};
+
+const mockTrainer: Trainer = {
+  id: 'trainer1',
+  name: 'Diego Lamas',
+  availableSlots: ['09:00', '10:00', '11:00']
+};
+
+const makeWeeklySchedule = (mondaySlots: { time: string; available: boolean }[]): TrainerSchedule => ({
+  trainerId: 'trainer1',
+  trainerName: 'Diego Lamas',
+  weeklySchedule: [
+    { day: 'Lunes', slots: mondaySlots },
+    { day: 'Martes', slots: [] },
+    { day: 'Miércoles', slots: [] },
+    { day: 'Jueves', slots: [] },
+    { day: 'Viernes', slots: [] },
+    { day: 'Sábado', slots: [] }
+  ]
+});
+
+describe('ScheduleModel', () => {
+  let scheduleModel: ScheduleModel;
+
+  beforeEach(() => {
+    scheduleModel = new ScheduleModel(mockDataService);
+    vi.clearAllMocks();
+  });
+
+  describe('getTrainerSchedule', () => {
+    it('retorna el horario del trainer del repositorio', async () => {
+      const mockSchedule: TrainerSchedule = {
+        trainerId: 'trainer1',
+        trainerName: 'Diego Lamas',
+        weeklySchedule: []
+      };
+      mockTrainerRepository.getSchedule.mockResolvedValue(mockSchedule);
+
+      const result = await scheduleModel.getTrainerSchedule('trainer1');
+
+      expect(result).toEqual(mockSchedule);
+      expect(mockTrainerRepository.getSchedule).toHaveBeenCalledWith('trainer1');
+    });
+
+    it('retorna null si no hay horario configurado', async () => {
+      mockTrainerRepository.getSchedule.mockResolvedValue(null);
+
+      const result = await scheduleModel.getTrainerSchedule('trainer1');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getAvailableSlots', () => {
+    it('retorna slots del horario del entrenador para el día correcto', async () => {
+      const monday = new Date('2024-01-15'); // lunes
+      const mockSchedule = makeWeeklySchedule([
+        { time: '09:00', available: true },
+        { time: '10:00', available: true },
+        { time: '11:00', available: false }
+      ]);
+      mockTrainerRepository.getById.mockResolvedValue(mockTrainer);
+      mockTrainerRepository.getSchedule.mockResolvedValue(mockSchedule);
+
+      const result = await scheduleModel.getAvailableSlots('trainer1', monday);
+
+      expect(result).toEqual(['09:00', '10:00']);
+    });
+
+    it('excluye slots marcados como no disponibles', async () => {
+      const monday = new Date('2024-01-15');
+      const mockSchedule = makeWeeklySchedule([
+        { time: '09:00', available: false },
+        { time: '10:00', available: false },
+        { time: '11:00', available: true }
+      ]);
+      mockTrainerRepository.getById.mockResolvedValue(mockTrainer);
+      mockTrainerRepository.getSchedule.mockResolvedValue(mockSchedule);
+
+      const result = await scheduleModel.getAvailableSlots('trainer1', monday);
+
+      expect(result).toEqual(['11:00']);
+    });
+
+    it('retorna trainer.availableSlots si no hay horario configurado', async () => {
+      const date = new Date('2024-01-15');
+      mockTrainerRepository.getById.mockResolvedValue(mockTrainer);
+      mockTrainerRepository.getSchedule.mockResolvedValue(null);
+
+      const result = await scheduleModel.getAvailableSlots('trainer1', date);
+
+      expect(result).toEqual(['09:00', '10:00', '11:00']);
+    });
+
+    it('retorna array vacío si el entrenador no existe', async () => {
+      mockTrainerRepository.getById.mockResolvedValue(null);
+
+      const result = await scheduleModel.getAvailableSlots('nonexistent', new Date());
+
+      expect(result).toEqual([]);
+    });
+
+    it('retorna array vacío para domingo (día no laboral)', async () => {
+      const sunday = new Date('2024-01-14'); // domingo
+      const mockSchedule = makeWeeklySchedule([
+        { time: '09:00', available: true }
+      ]);
+      mockTrainerRepository.getById.mockResolvedValue(mockTrainer);
+      mockTrainerRepository.getSchedule.mockResolvedValue(mockSchedule);
+
+      const result = await scheduleModel.getAvailableSlots('trainer1', sunday);
+
+      expect(result).toEqual([]);
+    });
+
+    it('no mezcla slots de otros días de la semana', async () => {
+      const tuesday = new Date('2024-01-16'); // martes
+      const schedule: TrainerSchedule = {
+        trainerId: 'trainer1',
+        trainerName: 'Diego Lamas',
+        weeklySchedule: [
+          { day: 'Lunes', slots: [{ time: '09:00', available: true }] },
+          { day: 'Martes', slots: [{ time: '14:00', available: true }] },
+          { day: 'Miércoles', slots: [] },
+          { day: 'Jueves', slots: [] },
+          { day: 'Viernes', slots: [] },
+          { day: 'Sábado', slots: [] }
+        ]
+      };
+      mockTrainerRepository.getById.mockResolvedValue(mockTrainer);
+      mockTrainerRepository.getSchedule.mockResolvedValue(schedule);
+
+      const result = await scheduleModel.getAvailableSlots('trainer1', tuesday);
+
+      expect(result).toEqual(['14:00']);
+    });
+  });
+
+  describe('isSlotAvailable', () => {
+    it('retorna true si el slot está disponible', async () => {
+      const monday = new Date('2024-01-15');
+      mockTrainerRepository.getById.mockResolvedValue(mockTrainer);
+      mockTrainerRepository.getSchedule.mockResolvedValue(null);
+
+      const result = await scheduleModel.isSlotAvailable('trainer1', monday, '09:00');
+
+      expect(result).toBe(true);
+    });
+
+    it('retorna false si el slot no está en los slots disponibles', async () => {
+      const monday = new Date('2024-01-15');
+      mockTrainerRepository.getById.mockResolvedValue(mockTrainer);
+      mockTrainerRepository.getSchedule.mockResolvedValue(null);
+
+      const result = await scheduleModel.isSlotAvailable('trainer1', monday, '15:00');
+
+      expect(result).toBe(false);
+    });
+
+    it('retorna false si no hay horario configurado para el entrenador', async () => {
+      mockTrainerRepository.getById.mockResolvedValue(null);
+
+      const result = await scheduleModel.isSlotAvailable('nonexistent', new Date(), '09:00');
+
+      expect(result).toBe(false);
+    });
+
+    it('retorna false para slot marcado como no disponible en el horario', async () => {
+      const monday = new Date('2024-01-15');
+      const mockSchedule = makeWeeklySchedule([
+        { time: '09:00', available: false },
+        { time: '10:00', available: true }
+      ]);
+      mockTrainerRepository.getById.mockResolvedValue(mockTrainer);
+      mockTrainerRepository.getSchedule.mockResolvedValue(mockSchedule);
+
+      const result = await scheduleModel.isSlotAvailable('trainer1', monday, '09:00');
+
+      expect(result).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Implementa los cambios del issue #94:

- Crea `ScheduleModel` con `getAvailableSlots`, `isSlotAvailable` y `getTrainerSchedule`
- Refactoriza `BookingModel.getAvailableSlots` para delegar lookup de horario a `ScheduleModel` (BookingModel solo verifica capacidad)
- `TrainerViewModel` usa `ScheduleModel` y resetea `currentSchedule` al cambiar de entrenador
- Actualiza `ViewModelProvider` para crear e inyectar `ScheduleModel`
- 12 tests unitarios nuevos para `ScheduleModel`

Closes #94

Generated with [Claude Code](https://claude.ai/code)