### PR TITLE
feat: implementar ClientModel y eliminar clientId hardcodeado (#95)

### DIFF
--- a/src/core/models/BookingModel.ts
+++ b/src/core/models/BookingModel.ts
@@ -1,15 +1,22 @@
 import { Booking, Trainer, ZoneType, ZONE_CONFIG } from '../types';
 import { BookingCapacityError, BookingValidationError } from '../types/errors';
 import { IDataService } from '../repositories';
+import { ClientModel } from './ClientModel';
 import { isSameDay } from 'date-fns';
 
 export class BookingModel {
-  constructor(private dataService: IDataService) {}
+  constructor(
+    private dataService: IDataService,
+    private clientModel: ClientModel
+  ) {}
 
   async createBooking(booking: Omit<Booking, 'id'>): Promise<Booking> {
     // Validaciones de negocio
     this.validateBooking(booking);
-    
+
+    // Verificar que el cliente existe
+    await this.clientModel.validateClientExists(booking.clientId);
+
     // Verificar disponibilidad
     await this.checkAvailability(booking.trainerId, booking.date, booking.time);
     

--- a/src/core/models/ClientModel.ts
+++ b/src/core/models/ClientModel.ts
@@ -1,0 +1,39 @@
+import { Client } from '../types';
+import { ClientNotFoundError } from '../types/errors';
+import { IDataService } from '../repositories';
+
+export class ClientModel {
+  constructor(private dataService: IDataService) {}
+
+  async getClientById(id: string): Promise<Client> {
+    const client = await this.dataService.clients.getById(id);
+    if (!client) {
+      throw new ClientNotFoundError(id);
+    }
+    return client;
+  }
+
+  async validateClientExists(id: string): Promise<void> {
+    await this.getClientById(id);
+  }
+
+  async createClient(data: Omit<Client, 'id'>): Promise<Client> {
+    const existing = await this.dataService.clients.getByEmail(data.email);
+    if (existing) {
+      throw new Error(`Ya existe un cliente con el email: ${data.email}`);
+    }
+
+    const newClient: Client = {
+      ...data,
+      id: `client_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+    };
+
+    await this.dataService.clients.save(newClient);
+    return newClient;
+  }
+
+  async deactivateClient(id: string): Promise<void> {
+    const client = await this.getClientById(id);
+    await this.dataService.clients.save({ ...client, status: 'inactive' });
+  }
+}

--- a/src/core/providers/ViewModelProvider.tsx
+++ b/src/core/providers/ViewModelProvider.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useMemo, ReactNode } from 'react';
 import { BookingViewModel } from '../view-models/BookingViewModel';
 import { BookingModel } from '../models/BookingModel';
+import { ClientModel } from '../models/ClientModel';
 import { ProgramViewModel } from '../view-models/ProgramViewModel';
 import { ProgramModel } from '../models/ProgramModel';
 import { TrainerViewModel } from '../view-models/TrainerViewModel';
@@ -25,7 +26,8 @@ export function ViewModelProvider({ children }: ViewModelProviderProps) {
   const { service } = useData();
 
   const viewModels = useMemo(() => {
-    const bookingModel = new BookingModel(service);
+    const clientModel = new ClientModel(service);
+    const bookingModel = new BookingModel(service, clientModel);
     const programModel = new ProgramModel(service);
     const trainerModel = new TrainerModel(service);
 

--- a/src/core/types/errors.ts
+++ b/src/core/types/errors.ts
@@ -68,3 +68,10 @@ export class TrainerValidationError extends Error {
     this.name = 'TrainerValidationError';
   }
 }
+
+export class ClientNotFoundError extends Error {
+  constructor(public clientId: string) {
+    super(`Cliente no encontrado: ${clientId}`);
+    this.name = 'ClientNotFoundError';
+  }
+}

--- a/src/core/view-models/BookingViewModel.ts
+++ b/src/core/view-models/BookingViewModel.ts
@@ -33,7 +33,7 @@ export class BookingViewModel {
   selectedTrainer: Trainer | null = null;
   selectedTime: string | null = null;
   selectedZone: ZoneType | null = null;
-  clientId = 'client1'; // En una app real vendría de un selector de clientes
+  clientId = '';
   
   // Estado de modales
   showSuccessModal = false;
@@ -48,7 +48,9 @@ export class BookingViewModel {
     if (this.trainers.length === 0) {
       this.loadTrainers();
     }
-    this.loadActiveProgram(this.clientId);
+    if (this.clientId) {
+      this.loadActiveProgram(this.clientId);
+    }
   }
 
   // Acciones

--- a/tests/unit/core/models/BookingModel.test.ts
+++ b/tests/unit/core/models/BookingModel.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { BookingModel } from '@/core/models/BookingModel'
+import { ClientModel } from '@/core/models/ClientModel'
 import { IDataService } from '@/core/repositories'
 import { Booking, Trainer, ZoneType } from '@/core/types'
 import { BookingCapacityError, BookingValidationError } from '@/core/types/errors'
@@ -47,12 +48,20 @@ const mockDataService: IDataService = {
   clear: vi.fn()
 }
 
+const mockClientModel = {
+  getClientById: vi.fn(),
+  validateClientExists: vi.fn(),
+  createClient: vi.fn(),
+  deactivateClient: vi.fn()
+}
+
 describe('BookingModel', () => {
   let bookingModel: BookingModel
 
   beforeEach(() => {
-    bookingModel = new BookingModel(mockDataService)
+    bookingModel = new BookingModel(mockDataService, mockClientModel as unknown as ClientModel)
     vi.clearAllMocks()
+    mockClientModel.validateClientExists.mockResolvedValue(undefined)
   })
 
   describe('createBooking', () => {

--- a/tests/unit/core/models/ClientModel.test.ts
+++ b/tests/unit/core/models/ClientModel.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ClientModel } from '@/core/models/ClientModel';
+import { IDataService } from '@/core/repositories';
+import { Client } from '@/core/types';
+import { ClientNotFoundError } from '@/core/types/errors';
+
+const mockClientRepository = {
+  getAll: vi.fn(),
+  getById: vi.fn(),
+  getByEmail: vi.fn(),
+  save: vi.fn(),
+  delete: vi.fn()
+};
+
+const mockDataService: IDataService = {
+  clients: mockClientRepository,
+  trainers: {
+    getAll: vi.fn(),
+    getById: vi.fn(),
+    save: vi.fn(),
+    saveSchedule: vi.fn(),
+    getSchedule: vi.fn()
+  },
+  bookings: {
+    getAll: vi.fn(),
+    getById: vi.fn(),
+    getByDate: vi.fn(),
+    getByTrainer: vi.fn(),
+    save: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn()
+  },
+  programs: {
+    getAll: vi.fn(),
+    getById: vi.fn(),
+    getByTrainer: vi.fn(),
+    getByClient: vi.fn(),
+    save: vi.fn(),
+    delete: vi.fn()
+  },
+  initialize: vi.fn(),
+  clear: vi.fn()
+};
+
+const mockClient: Client = {
+  id: 'client1',
+  name: 'Ana García',
+  email: 'ana@example.com',
+  phone: '555-0001',
+  status: 'active',
+  createdAt: new Date('2025-01-01')
+};
+
+describe('ClientModel', () => {
+  let clientModel: ClientModel;
+
+  beforeEach(() => {
+    clientModel = new ClientModel(mockDataService);
+    vi.clearAllMocks();
+  });
+
+  describe('getClientById', () => {
+    it('retorna el cliente cuando existe', async () => {
+      mockClientRepository.getById.mockResolvedValue(mockClient);
+
+      const result = await clientModel.getClientById('client1');
+
+      expect(result).toEqual(mockClient);
+      expect(mockClientRepository.getById).toHaveBeenCalledWith('client1');
+    });
+
+    it('lanza ClientNotFoundError para un ID inexistente', async () => {
+      mockClientRepository.getById.mockResolvedValue(null);
+
+      await expect(clientModel.getClientById('nonexistent')).rejects.toThrow(ClientNotFoundError);
+      await expect(clientModel.getClientById('nonexistent')).rejects.toThrow('Cliente no encontrado: nonexistent');
+    });
+  });
+
+  describe('validateClientExists', () => {
+    it('resuelve sin error cuando el cliente existe', async () => {
+      mockClientRepository.getById.mockResolvedValue(mockClient);
+
+      await expect(clientModel.validateClientExists('client1')).resolves.toBeUndefined();
+    });
+
+    it('lanza ClientNotFoundError cuando el cliente no existe', async () => {
+      mockClientRepository.getById.mockResolvedValue(null);
+
+      await expect(clientModel.validateClientExists('nonexistent')).rejects.toThrow(ClientNotFoundError);
+    });
+  });
+
+  describe('createClient', () => {
+    const newClientData: Omit<Client, 'id'> = {
+      name: 'Carlos López',
+      email: 'carlos@example.com',
+      phone: '555-0002',
+      status: 'active',
+      createdAt: new Date('2026-01-01')
+    };
+
+    it('crea y persiste un nuevo cliente cuando el email no existe', async () => {
+      mockClientRepository.getByEmail.mockResolvedValue(null);
+      mockClientRepository.save.mockResolvedValue(undefined);
+
+      const result = await clientModel.createClient(newClientData);
+
+      expect(result).toMatchObject(newClientData);
+      expect(result.id).toBeDefined();
+      expect(result.id).toMatch(/^client_\d+_[a-z0-9]+$/);
+      expect(mockClientRepository.save).toHaveBeenCalledWith(result);
+    });
+
+    it('lanza error cuando ya existe un cliente con el mismo email', async () => {
+      mockClientRepository.getByEmail.mockResolvedValue(mockClient);
+
+      await expect(clientModel.createClient(newClientData)).rejects.toThrow(
+        'Ya existe un cliente con el email: carlos@example.com'
+      );
+      expect(mockClientRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deactivateClient', () => {
+    it('desactiva un cliente activo', async () => {
+      mockClientRepository.getById.mockResolvedValue(mockClient);
+      mockClientRepository.save.mockResolvedValue(undefined);
+
+      await clientModel.deactivateClient('client1');
+
+      expect(mockClientRepository.save).toHaveBeenCalledWith({
+        ...mockClient,
+        status: 'inactive'
+      });
+    });
+
+    it('lanza ClientNotFoundError si el cliente no existe', async () => {
+      mockClientRepository.getById.mockResolvedValue(null);
+
+      await expect(clientModel.deactivateClient('nonexistent')).rejects.toThrow(ClientNotFoundError);
+      expect(mockClientRepository.save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/core/view-models/BookingViewModel.test.ts
+++ b/tests/unit/core/view-models/BookingViewModel.test.ts
@@ -181,6 +181,7 @@ describe('BookingViewModel', () => {
       mockBookingModel.getTrainers.mockResolvedValue([mockTrainer]);
       await vm.loadTrainers();
 
+      vm.setClientId('client1');
       vm.setDate(new Date(Date.now() + 24 * 60 * 60 * 1000));
       vm.setTrainer('trainer1');
 


### PR DESCRIPTION
Implementa ClientModel y elimina el clientId hardcodeado según lo definido en issue #95.

## Cambios

- Agrega `ClientNotFoundError` a `src/core/types/errors.ts`
- Crea `ClientModel` con validación de existencia, creación y desactivación de clientes
- `BookingModel.createBooking` ahora valida que el cliente exista antes de crear una reserva
- Elimina `clientId = 'client1'` hardcodeado en `BookingViewModel`
- Actualiza `ViewModelProvider` para instanciar e inyectar `ClientModel`
- 8 nuevos tests unitarios para `ClientModel`

Closes #95

Generated with [Claude Code](https://claude.ai/code)