### PR TITLE
feat(mappers): add Supabase row types and domain mappers

### DIFF
--- a/src/core/mappers/BookingMapper.ts
+++ b/src/core/mappers/BookingMapper.ts
@@ -1,0 +1,32 @@
+import { parseISO, format } from 'date-fns';
+import { Booking } from '../types';
+import { BookingInsert, BookingRow } from '../types/supabase';
+
+export class BookingMapper {
+  static toDomain(row: BookingRow): Booking {
+    return {
+      id: row.id,
+      clientId: row.client_id,
+      trainerId: row.trainer_id,
+      trainerName: row.trainer_name,
+      date: parseISO(row.date),
+      time: row.time_slot,
+      duration: row.duration_minutes,
+      zone: row.zone,
+      status: row.status,
+    };
+  }
+
+  static toInsert(booking: Omit<Booking, 'id'>): BookingInsert {
+    return {
+      client_id: booking.clientId,
+      trainer_id: booking.trainerId,
+      trainer_name: booking.trainerName,
+      date: format(booking.date, 'yyyy-MM-dd'),
+      time_slot: booking.time,
+      duration_minutes: booking.duration,
+      zone: booking.zone,
+      status: booking.status,
+    };
+  }
+}

--- a/src/core/mappers/ClientMapper.ts
+++ b/src/core/mappers/ClientMapper.ts
@@ -1,0 +1,22 @@
+import { parseISO } from 'date-fns';
+import { Client } from '../types';
+import { UserProfileRow } from '../types/supabase';
+
+export class ClientMapper {
+  // UserProfileRow does not include email or phone — those live in auth.users.
+  // The caller must fetch those fields from the Supabase Auth API and pass them in.
+  static toDomain(
+    row: UserProfileRow,
+    email: string,
+    phone: string = '',
+  ): Client {
+    return {
+      id: row.id,
+      name: row.full_name ?? email,
+      email,
+      phone,
+      status: 'active',
+      createdAt: parseISO(row.created_at),
+    };
+  }
+}

--- a/src/core/mappers/ProgramMapper.ts
+++ b/src/core/mappers/ProgramMapper.ts
@@ -1,0 +1,36 @@
+import { format, parseISO } from 'date-fns';
+import { Program } from '../types';
+import { ProgramInsert, ProgramRow } from '../types/supabase';
+
+export class ProgramMapper {
+  static toDomain(row: ProgramRow): Program {
+    return {
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      trainerId: row.trainer_id,
+      clientIds: row.client_ids,
+      startDate: parseISO(row.start_date),
+      endDate: parseISO(row.end_date),
+      totalSessions: row.total_sessions,
+      usedSessions: row.used_sessions,
+      status: row.status,
+      ...(row.previous_program_id !== null && { previousProgramId: row.previous_program_id }),
+    };
+  }
+
+  static toInsert(program: Omit<Program, 'id'>): ProgramInsert {
+    return {
+      name: program.name,
+      description: program.description,
+      trainer_id: program.trainerId,
+      client_ids: program.clientIds,
+      start_date: format(program.startDate, 'yyyy-MM-dd'),
+      end_date: format(program.endDate, 'yyyy-MM-dd'),
+      total_sessions: program.totalSessions,
+      used_sessions: program.usedSessions,
+      status: program.status,
+      previous_program_id: program.previousProgramId ?? null,
+    };
+  }
+}

--- a/src/core/mappers/TrainerMapper.ts
+++ b/src/core/mappers/TrainerMapper.ts
@@ -1,0 +1,14 @@
+import { Trainer } from '../types';
+import { TrainerRow } from '../types/supabase';
+
+export class TrainerMapper {
+  // availableSlots is not stored in the trainers table — it derives from trainer_schedules.
+  // Callers populate it by passing the result of TrainerScheduleMapper.toAvailableSlots().
+  static toDomain(row: TrainerRow, availableSlots: string[] = []): Trainer {
+    return {
+      id: row.id,
+      name: row.name,
+      availableSlots,
+    };
+  }
+}

--- a/src/core/mappers/TrainerScheduleMapper.ts
+++ b/src/core/mappers/TrainerScheduleMapper.ts
@@ -1,0 +1,99 @@
+import { addDays, format, getDay, startOfWeek } from 'date-fns';
+import { DaySchedule, TimeSlot, TrainerSchedule } from '../types';
+import { TrainerScheduleInsert, TrainerScheduleRow } from '../types/supabase';
+
+// Structural note: The domain TrainerSchedule uses a weekly pattern (Mon–Sat indexed 0–5).
+// Supabase stores one row per slot per specific calendar date.
+// These mappers bridge that gap in both directions.
+
+const DAY_NAMES = ['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'] as const;
+
+// Returns the weeklySchedule day index (0=Mon … 5=Sat) for a YYYY-MM-DD string.
+// Returns -1 for Sunday (not a working day).
+function toDayIndex(dateString: string): number {
+  const jsDay = new Date(dateString + 'T12:00:00').getDay(); // midday avoids DST edge cases
+  return jsDay === 0 ? -1 : jsDay - 1;
+}
+
+export class TrainerScheduleMapper {
+  // Builds a weekly TrainerSchedule from rows that may span multiple dates.
+  // Rows are grouped by day-of-week; the most permissive (any available=true) wins per slot.
+  static toDomain(
+    rows: TrainerScheduleRow[],
+    trainerId: string,
+    trainerName: string,
+  ): TrainerSchedule {
+    // Accumulate slots per day index
+    const slotsByDay = new Map<number, Map<string, boolean>>();
+
+    for (const row of rows) {
+      const dayIndex = toDayIndex(row.date);
+      if (dayIndex < 0) continue; // skip Sunday rows
+
+      if (!slotsByDay.has(dayIndex)) {
+        slotsByDay.set(dayIndex, new Map());
+      }
+      const daySlots = slotsByDay.get(dayIndex)!;
+      // If any row for this (day, slot) is available, mark it available
+      const current = daySlots.get(row.time_slot) ?? false;
+      daySlots.set(row.time_slot, current || row.is_available);
+    }
+
+    const weeklySchedule: DaySchedule[] = DAY_NAMES.map((day, index) => {
+      const daySlots = slotsByDay.get(index) ?? new Map<string, boolean>();
+      const slots: TimeSlot[] = Array.from(daySlots.entries())
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([time, available]) => ({ time, available }));
+      return { day, slots };
+    });
+
+    return { trainerId, trainerName, weeklySchedule };
+  }
+
+  // Returns the sorted list of available time strings for a specific date's rows.
+  // Used by SupabaseDataService.trainers.getAvailableSlots() for a single date lookup.
+  static toAvailableSlots(rows: TrainerScheduleRow[]): string[] {
+    return rows
+      .filter((r) => r.is_available)
+      .map((r) => r.time_slot)
+      .sort();
+  }
+
+  // Expands a weekly TrainerSchedule into insert rows for one calendar week.
+  // weekStartDate should be a Monday; the function covers Mon–Sat (6 days).
+  static toInsertRows(
+    schedule: TrainerSchedule,
+    weekStartDate: Date,
+  ): TrainerScheduleInsert[] {
+    const monday = startOfWeek(weekStartDate, { weekStartsOn: 1 });
+    const rows: TrainerScheduleInsert[] = [];
+
+    schedule.weeklySchedule.forEach((daySchedule, dayIndex) => {
+      // dayIndex 0=Mon … 5=Sat
+      const date = addDays(monday, dayIndex);
+      const dateString = format(date, 'yyyy-MM-dd');
+
+      for (const slot of daySchedule.slots) {
+        rows.push({
+          trainer_id: schedule.trainerId,
+          date: dateString,
+          time_slot: slot.time,
+          is_available: slot.available,
+        });
+      }
+    });
+
+    return rows;
+  }
+
+  // Convenience: day-of-week index → day name (for building DaySchedule manually).
+  static dayName(index: number): string {
+    return DAY_NAMES[index] ?? '';
+  }
+
+  // Returns the day index (0=Mon … 5=Sat, -1=Sun) for a given Date.
+  static dayIndexFromDate(date: Date): number {
+    const jsDay = getDay(date);
+    return jsDay === 0 ? -1 : jsDay - 1;
+  }
+}

--- a/src/core/mappers/index.ts
+++ b/src/core/mappers/index.ts
@@ -1,0 +1,5 @@
+export { BookingMapper } from './BookingMapper';
+export { ClientMapper } from './ClientMapper';
+export { ProgramMapper } from './ProgramMapper';
+export { TrainerMapper } from './TrainerMapper';
+export { TrainerScheduleMapper } from './TrainerScheduleMapper';

--- a/src/core/types/supabase.ts
+++ b/src/core/types/supabase.ts
@@ -1,0 +1,63 @@
+// Row types that match exactly the Supabase PostgreSQL schema columns.
+// Used exclusively by mappers — domain code never imports these directly.
+
+export type UserRole = 'client' | 'trainer';
+
+export interface TrainerRow {
+  id: string;               // UUID, PK
+  user_id: string;          // UUID, FK → auth.users.id
+  name: string;
+  email: string;
+  specialization: string | null;
+  is_active: boolean;
+  created_at: string;       // ISO timestamp
+}
+
+export interface TrainerScheduleRow {
+  id: string;               // UUID, PK
+  trainer_id: string;       // UUID, FK → trainers.id
+  date: string;             // YYYY-MM-DD (specific calendar date)
+  time_slot: string;        // HH:MM
+  is_available: boolean;
+  created_at: string;
+}
+
+export interface BookingRow {
+  id: string;               // UUID, PK
+  client_id: string;        // UUID, FK → auth.users.id
+  trainer_id: string;       // UUID, FK → trainers.id
+  trainer_name: string;     // Denormalized for read performance
+  date: string;             // YYYY-MM-DD
+  time_slot: string;        // HH:MM
+  duration_minutes: number;
+  zone: 'gym' | 'gabinete';
+  status: 'confirmed' | 'cancelled' | 'pending';
+  created_at: string;
+}
+
+export interface UserProfileRow {
+  id: string;               // UUID, PK = auth.users.id
+  role: UserRole;
+  full_name: string | null;
+  created_at: string;
+}
+
+export interface ProgramRow {
+  id: string;               // UUID, PK
+  name: string;
+  description: string;
+  trainer_id: string;       // UUID, FK → trainers.id
+  client_ids: string[];     // UUID[] stored as jsonb
+  start_date: string;       // YYYY-MM-DD
+  end_date: string;         // YYYY-MM-DD
+  total_sessions: number;
+  used_sessions: number;
+  status: 'active' | 'inactive' | 'expired';
+  previous_program_id: string | null;  // FK → programs.id (renewal chain)
+  created_at: string;
+}
+
+// Insert types omit server-generated fields (id, created_at)
+export type BookingInsert = Omit<BookingRow, 'id' | 'created_at'>;
+export type ProgramInsert = Omit<ProgramRow, 'id' | 'created_at'>;
+export type TrainerScheduleInsert = Omit<TrainerScheduleRow, 'id' | 'created_at'>;

--- a/tests/unit/core/mappers/BookingMapper.test.ts
+++ b/tests/unit/core/mappers/BookingMapper.test.ts
@@ -64,7 +64,7 @@ describe('BookingMapper', () => {
     })
 
     it('does not include created_at in the domain entity', () => {
-      const result = BookingMapper.toDomain(baseRow) as Record<string, unknown>
+      const result = BookingMapper.toDomain(baseRow) as unknown as Record<string, unknown>
 
       expect(result['created_at']).toBeUndefined()
     })
@@ -90,7 +90,7 @@ describe('BookingMapper', () => {
     })
 
     it('does not include id in the insert payload', () => {
-      const result = BookingMapper.toInsert(baseDomain) as Record<string, unknown>
+      const result = BookingMapper.toInsert(baseDomain) as unknown as Record<string, unknown>
 
       expect(result['id']).toBeUndefined()
     })

--- a/tests/unit/core/mappers/BookingMapper.test.ts
+++ b/tests/unit/core/mappers/BookingMapper.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import { BookingMapper } from '@/core/mappers/BookingMapper'
+import { Booking } from '@/core/types'
+import { BookingInsert, BookingRow } from '@/core/types/supabase'
+
+const baseRow: BookingRow = {
+  id: 'uuid-booking-1',
+  client_id: 'uuid-client-1',
+  trainer_id: 'uuid-trainer-1',
+  trainer_name: 'Carlos López',
+  date: '2026-05-15',
+  time_slot: '09:00',
+  duration_minutes: 60,
+  zone: 'gym',
+  status: 'confirmed',
+  created_at: '2026-05-10T12:00:00Z',
+}
+
+const baseDomain: Omit<Booking, 'id'> = {
+  clientId: 'uuid-client-1',
+  trainerId: 'uuid-trainer-1',
+  trainerName: 'Carlos López',
+  date: new Date('2026-05-15T12:00:00.000Z'),
+  time: '09:00',
+  duration: 60,
+  zone: 'gym',
+  status: 'confirmed',
+}
+
+describe('BookingMapper', () => {
+  describe('toDomain', () => {
+    it('maps all snake_case fields to camelCase', () => {
+      const result = BookingMapper.toDomain(baseRow)
+
+      expect(result.id).toBe('uuid-booking-1')
+      expect(result.clientId).toBe('uuid-client-1')
+      expect(result.trainerId).toBe('uuid-trainer-1')
+      expect(result.trainerName).toBe('Carlos López')
+      expect(result.time).toBe('09:00')
+      expect(result.duration).toBe(60)
+      expect(result.zone).toBe('gym')
+      expect(result.status).toBe('confirmed')
+    })
+
+    it('parses the date string into a Date object', () => {
+      const result = BookingMapper.toDomain(baseRow)
+
+      expect(result.date).toBeInstanceOf(Date)
+      expect(result.date.getFullYear()).toBe(2026)
+      expect(result.date.getMonth()).toBe(4) // May = 4 (0-indexed)
+      expect(result.date.getDate()).toBe(15)
+    })
+
+    it('maps zone gabinete correctly', () => {
+      const result = BookingMapper.toDomain({ ...baseRow, zone: 'gabinete' })
+
+      expect(result.zone).toBe('gabinete')
+    })
+
+    it('maps all booking status values', () => {
+      expect(BookingMapper.toDomain({ ...baseRow, status: 'confirmed' }).status).toBe('confirmed')
+      expect(BookingMapper.toDomain({ ...baseRow, status: 'cancelled' }).status).toBe('cancelled')
+      expect(BookingMapper.toDomain({ ...baseRow, status: 'pending' }).status).toBe('pending')
+    })
+
+    it('does not include created_at in the domain entity', () => {
+      const result = BookingMapper.toDomain(baseRow) as Record<string, unknown>
+
+      expect(result['created_at']).toBeUndefined()
+    })
+  })
+
+  describe('toInsert', () => {
+    it('maps all camelCase fields to snake_case', () => {
+      const result = BookingMapper.toInsert(baseDomain)
+
+      expect(result.client_id).toBe('uuid-client-1')
+      expect(result.trainer_id).toBe('uuid-trainer-1')
+      expect(result.trainer_name).toBe('Carlos López')
+      expect(result.time_slot).toBe('09:00')
+      expect(result.duration_minutes).toBe(60)
+      expect(result.zone).toBe('gym')
+      expect(result.status).toBe('confirmed')
+    })
+
+    it('formats the Date object as YYYY-MM-DD string', () => {
+      const result = BookingMapper.toInsert(baseDomain)
+
+      expect(result.date).toBe('2026-05-15')
+    })
+
+    it('does not include id in the insert payload', () => {
+      const result = BookingMapper.toInsert(baseDomain) as Record<string, unknown>
+
+      expect(result['id']).toBeUndefined()
+    })
+
+    it('round-trips correctly: toDomain(toInsert(domain)) === domain', () => {
+      const insert: BookingInsert = BookingMapper.toInsert(baseDomain)
+      const roundTripped = BookingMapper.toDomain({ ...insert, id: 'new-id', created_at: '' })
+
+      expect(roundTripped.clientId).toBe(baseDomain.clientId)
+      expect(roundTripped.trainerId).toBe(baseDomain.trainerId)
+      expect(roundTripped.trainerName).toBe(baseDomain.trainerName)
+      expect(roundTripped.time).toBe(baseDomain.time)
+      expect(roundTripped.duration).toBe(baseDomain.duration)
+      expect(roundTripped.zone).toBe(baseDomain.zone)
+      expect(roundTripped.status).toBe(baseDomain.status)
+    })
+  })
+})

--- a/tests/unit/core/mappers/ClientMapper.test.ts
+++ b/tests/unit/core/mappers/ClientMapper.test.ts
@@ -63,7 +63,7 @@ describe('ClientMapper', () => {
     })
 
     it('does not expose role or created_at as raw strings on the domain entity', () => {
-      const result = ClientMapper.toDomain(baseRow, 'alice@gym.com') as Record<string, unknown>
+      const result = ClientMapper.toDomain(baseRow, 'alice@gym.com') as unknown as Record<string, unknown>
 
       expect(result['role']).toBeUndefined()
       expect(result['created_at']).toBeUndefined()

--- a/tests/unit/core/mappers/ClientMapper.test.ts
+++ b/tests/unit/core/mappers/ClientMapper.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { ClientMapper } from '@/core/mappers/ClientMapper'
+import { UserProfileRow } from '@/core/types/supabase'
+
+const baseRow: UserProfileRow = {
+  id: 'uuid-client-1',
+  role: 'client',
+  full_name: 'Alice García',
+  created_at: '2026-01-15T10:00:00Z',
+}
+
+describe('ClientMapper', () => {
+  describe('toDomain', () => {
+    it('maps id from the row', () => {
+      const result = ClientMapper.toDomain(baseRow, 'alice@gym.com')
+
+      expect(result.id).toBe('uuid-client-1')
+    })
+
+    it('uses full_name as the client name when it is set', () => {
+      const result = ClientMapper.toDomain(baseRow, 'alice@gym.com')
+
+      expect(result.name).toBe('Alice García')
+    })
+
+    it('falls back to email as name when full_name is null', () => {
+      const result = ClientMapper.toDomain({ ...baseRow, full_name: null }, 'alice@gym.com')
+
+      expect(result.name).toBe('alice@gym.com')
+    })
+
+    it('assigns the provided email', () => {
+      const result = ClientMapper.toDomain(baseRow, 'alice@gym.com')
+
+      expect(result.email).toBe('alice@gym.com')
+    })
+
+    it('defaults phone to empty string when not provided', () => {
+      const result = ClientMapper.toDomain(baseRow, 'alice@gym.com')
+
+      expect(result.phone).toBe('')
+    })
+
+    it('uses the provided phone when given', () => {
+      const result = ClientMapper.toDomain(baseRow, 'alice@gym.com', '+52 55 1234 5678')
+
+      expect(result.phone).toBe('+52 55 1234 5678')
+    })
+
+    it('always sets status to active', () => {
+      const result = ClientMapper.toDomain(baseRow, 'alice@gym.com')
+
+      expect(result.status).toBe('active')
+    })
+
+    it('parses created_at into a Date object', () => {
+      const result = ClientMapper.toDomain(baseRow, 'alice@gym.com')
+
+      expect(result.createdAt).toBeInstanceOf(Date)
+      expect(result.createdAt.getFullYear()).toBe(2026)
+      expect(result.createdAt.getMonth()).toBe(0) // January
+      expect(result.createdAt.getDate()).toBe(15)
+    })
+
+    it('does not expose role or created_at as raw strings on the domain entity', () => {
+      const result = ClientMapper.toDomain(baseRow, 'alice@gym.com') as Record<string, unknown>
+
+      expect(result['role']).toBeUndefined()
+      expect(result['created_at']).toBeUndefined()
+      expect(result['full_name']).toBeUndefined()
+    })
+  })
+})

--- a/tests/unit/core/mappers/ProgramMapper.test.ts
+++ b/tests/unit/core/mappers/ProgramMapper.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest'
+import { ProgramMapper } from '@/core/mappers/ProgramMapper'
+import { Program } from '@/core/types'
+import { ProgramRow } from '@/core/types/supabase'
+
+const baseRow: ProgramRow = {
+  id: 'uuid-program-1',
+  name: 'Plan Fuerza 12 semanas',
+  description: 'Programa de fuerza progresiva',
+  trainer_id: 'uuid-trainer-1',
+  client_ids: ['uuid-client-1', 'uuid-client-2'],
+  start_date: '2026-05-01',
+  end_date: '2026-07-24',
+  total_sessions: 24,
+  used_sessions: 4,
+  status: 'active',
+  previous_program_id: null,
+  created_at: '2026-04-30T10:00:00Z',
+}
+
+const baseDomain: Omit<Program, 'id'> = {
+  name: 'Plan Fuerza 12 semanas',
+  description: 'Programa de fuerza progresiva',
+  trainerId: 'uuid-trainer-1',
+  clientIds: ['uuid-client-1', 'uuid-client-2'],
+  startDate: new Date('2026-05-01'),
+  endDate: new Date('2026-07-24'),
+  totalSessions: 24,
+  usedSessions: 4,
+  status: 'active',
+}
+
+describe('ProgramMapper', () => {
+  describe('toDomain', () => {
+    it('maps all snake_case fields to camelCase', () => {
+      const result = ProgramMapper.toDomain(baseRow)
+
+      expect(result.id).toBe('uuid-program-1')
+      expect(result.name).toBe('Plan Fuerza 12 semanas')
+      expect(result.description).toBe('Programa de fuerza progresiva')
+      expect(result.trainerId).toBe('uuid-trainer-1')
+      expect(result.clientIds).toEqual(['uuid-client-1', 'uuid-client-2'])
+      expect(result.totalSessions).toBe(24)
+      expect(result.usedSessions).toBe(4)
+      expect(result.status).toBe('active')
+    })
+
+    it('parses start_date and end_date into Date objects', () => {
+      const result = ProgramMapper.toDomain(baseRow)
+
+      expect(result.startDate).toBeInstanceOf(Date)
+      expect(result.endDate).toBeInstanceOf(Date)
+      expect(result.startDate.getFullYear()).toBe(2026)
+      expect(result.startDate.getMonth()).toBe(4) // May
+      expect(result.startDate.getDate()).toBe(1)
+    })
+
+    it('omits previousProgramId when previous_program_id is null', () => {
+      const result = ProgramMapper.toDomain({ ...baseRow, previous_program_id: null })
+
+      expect(result.previousProgramId).toBeUndefined()
+    })
+
+    it('maps previousProgramId when previous_program_id is set', () => {
+      const result = ProgramMapper.toDomain({
+        ...baseRow,
+        previous_program_id: 'uuid-prev-program',
+      })
+
+      expect(result.previousProgramId).toBe('uuid-prev-program')
+    })
+
+    it('maps all status values', () => {
+      expect(ProgramMapper.toDomain({ ...baseRow, status: 'active' }).status).toBe('active')
+      expect(ProgramMapper.toDomain({ ...baseRow, status: 'expired' }).status).toBe('expired')
+      expect(ProgramMapper.toDomain({ ...baseRow, status: 'inactive' }).status).toBe('inactive')
+    })
+
+    it('does not expose created_at on the domain entity', () => {
+      const result = ProgramMapper.toDomain(baseRow) as Record<string, unknown>
+
+      expect(result['created_at']).toBeUndefined()
+    })
+  })
+
+  describe('toInsert', () => {
+    it('maps all camelCase fields to snake_case', () => {
+      const result = ProgramMapper.toInsert(baseDomain)
+
+      expect(result.name).toBe('Plan Fuerza 12 semanas')
+      expect(result.description).toBe('Programa de fuerza progresiva')
+      expect(result.trainer_id).toBe('uuid-trainer-1')
+      expect(result.client_ids).toEqual(['uuid-client-1', 'uuid-client-2'])
+      expect(result.total_sessions).toBe(24)
+      expect(result.used_sessions).toBe(4)
+      expect(result.status).toBe('active')
+    })
+
+    it('formats startDate and endDate as YYYY-MM-DD strings', () => {
+      const result = ProgramMapper.toInsert(baseDomain)
+
+      expect(result.start_date).toBe('2026-05-01')
+      expect(result.end_date).toBe('2026-07-24')
+    })
+
+    it('sets previous_program_id to null when previousProgramId is undefined', () => {
+      const result = ProgramMapper.toInsert({ ...baseDomain, previousProgramId: undefined })
+
+      expect(result.previous_program_id).toBeNull()
+    })
+
+    it('maps previousProgramId to previous_program_id when set', () => {
+      const result = ProgramMapper.toInsert({ ...baseDomain, previousProgramId: 'uuid-prev' })
+
+      expect(result.previous_program_id).toBe('uuid-prev')
+    })
+
+    it('does not include id in the insert payload', () => {
+      const result = ProgramMapper.toInsert(baseDomain) as Record<string, unknown>
+
+      expect(result['id']).toBeUndefined()
+    })
+
+    it('round-trips correctly: toDomain(toInsert(domain)) === domain', () => {
+      const insert = ProgramMapper.toInsert(baseDomain)
+      const roundTripped = ProgramMapper.toDomain({ ...insert, id: 'new-id', created_at: '' })
+
+      expect(roundTripped.name).toBe(baseDomain.name)
+      expect(roundTripped.trainerId).toBe(baseDomain.trainerId)
+      expect(roundTripped.clientIds).toEqual(baseDomain.clientIds)
+      expect(roundTripped.totalSessions).toBe(baseDomain.totalSessions)
+      expect(roundTripped.usedSessions).toBe(baseDomain.usedSessions)
+      expect(roundTripped.status).toBe(baseDomain.status)
+    })
+  })
+})

--- a/tests/unit/core/mappers/ProgramMapper.test.ts
+++ b/tests/unit/core/mappers/ProgramMapper.test.ts
@@ -77,7 +77,7 @@ describe('ProgramMapper', () => {
     })
 
     it('does not expose created_at on the domain entity', () => {
-      const result = ProgramMapper.toDomain(baseRow) as Record<string, unknown>
+      const result = ProgramMapper.toDomain(baseRow) as unknown as Record<string, unknown>
 
       expect(result['created_at']).toBeUndefined()
     })
@@ -116,7 +116,7 @@ describe('ProgramMapper', () => {
     })
 
     it('does not include id in the insert payload', () => {
-      const result = ProgramMapper.toInsert(baseDomain) as Record<string, unknown>
+      const result = ProgramMapper.toInsert(baseDomain) as unknown as Record<string, unknown>
 
       expect(result['id']).toBeUndefined()
     })

--- a/tests/unit/core/mappers/TrainerMapper.test.ts
+++ b/tests/unit/core/mappers/TrainerMapper.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { TrainerMapper } from '@/core/mappers/TrainerMapper'
+import { TrainerRow } from '@/core/types/supabase'
+
+const baseRow: TrainerRow = {
+  id: 'uuid-trainer-1',
+  user_id: 'uuid-user-1',
+  name: 'Carlos López',
+  email: 'carlos@nivalgym.com',
+  specialization: 'Fuerza y acondicionamiento',
+  is_active: true,
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+describe('TrainerMapper', () => {
+  describe('toDomain', () => {
+    it('maps id and name from the row', () => {
+      const result = TrainerMapper.toDomain(baseRow)
+
+      expect(result.id).toBe('uuid-trainer-1')
+      expect(result.name).toBe('Carlos López')
+    })
+
+    it('defaults to empty availableSlots when not provided', () => {
+      const result = TrainerMapper.toDomain(baseRow)
+
+      expect(result.availableSlots).toEqual([])
+    })
+
+    it('uses provided availableSlots', () => {
+      const slots = ['09:00', '10:00', '11:00']
+      const result = TrainerMapper.toDomain(baseRow, slots)
+
+      expect(result.availableSlots).toEqual(slots)
+    })
+
+    it('does not expose email, specialization, is_active or created_at on the domain entity', () => {
+      const result = TrainerMapper.toDomain(baseRow) as Record<string, unknown>
+
+      expect(result['email']).toBeUndefined()
+      expect(result['specialization']).toBeUndefined()
+      expect(result['is_active']).toBeUndefined()
+      expect(result['created_at']).toBeUndefined()
+      expect(result['user_id']).toBeUndefined()
+    })
+
+    it('handles a trainer with null specialization', () => {
+      const result = TrainerMapper.toDomain({ ...baseRow, specialization: null })
+
+      expect(result.id).toBe('uuid-trainer-1')
+    })
+  })
+})

--- a/tests/unit/core/mappers/TrainerMapper.test.ts
+++ b/tests/unit/core/mappers/TrainerMapper.test.ts
@@ -35,7 +35,7 @@ describe('TrainerMapper', () => {
     })
 
     it('does not expose email, specialization, is_active or created_at on the domain entity', () => {
-      const result = TrainerMapper.toDomain(baseRow) as Record<string, unknown>
+      const result = TrainerMapper.toDomain(baseRow) as unknown as Record<string, unknown>
 
       expect(result['email']).toBeUndefined()
       expect(result['specialization']).toBeUndefined()

--- a/tests/unit/core/mappers/TrainerScheduleMapper.test.ts
+++ b/tests/unit/core/mappers/TrainerScheduleMapper.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from 'vitest'
+import { TrainerScheduleMapper } from '@/core/mappers/TrainerScheduleMapper'
+import { TrainerScheduleRow } from '@/core/types/supabase'
+
+// 2026-05-11 = Monday, 2026-05-12 = Tuesday, ..., 2026-05-16 = Saturday, 2026-05-17 = Sunday
+const MONDAY = '2026-05-11'
+const TUESDAY = '2026-05-12'
+const SATURDAY = '2026-05-16'
+const SUNDAY = '2026-05-17'
+
+function makeRow(overrides: Partial<TrainerScheduleRow> = {}): TrainerScheduleRow {
+  return {
+    id: 'uuid-schedule-1',
+    trainer_id: 'uuid-trainer-1',
+    date: MONDAY,
+    time_slot: '09:00',
+    is_available: true,
+    created_at: '2026-05-10T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('TrainerScheduleMapper', () => {
+  describe('toDomain', () => {
+    it('builds a TrainerSchedule with trainer metadata', () => {
+      const rows = [makeRow()]
+      const result = TrainerScheduleMapper.toDomain(rows, 'uuid-trainer-1', 'Carlos')
+
+      expect(result.trainerId).toBe('uuid-trainer-1')
+      expect(result.trainerName).toBe('Carlos')
+    })
+
+    it('produces a weeklySchedule with 6 entries (Mon–Sat)', () => {
+      const result = TrainerScheduleMapper.toDomain([], 'uuid-trainer-1', 'Carlos')
+
+      expect(result.weeklySchedule).toHaveLength(6)
+    })
+
+    it('assigns correct day names (Lunes … Sábado)', () => {
+      const result = TrainerScheduleMapper.toDomain([], 'uuid-trainer-1', 'Carlos')
+      const names = result.weeklySchedule.map((d) => d.day)
+
+      expect(names).toEqual(['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'])
+    })
+
+    it('places a Monday row into weeklySchedule index 0 (Lunes)', () => {
+      const rows = [makeRow({ date: MONDAY, time_slot: '09:00', is_available: true })]
+      const result = TrainerScheduleMapper.toDomain(rows, 't1', 'Carlos')
+
+      expect(result.weeklySchedule[0].day).toBe('Lunes')
+      expect(result.weeklySchedule[0].slots).toContainEqual({ time: '09:00', available: true })
+    })
+
+    it('places a Tuesday row into weeklySchedule index 1 (Martes)', () => {
+      const rows = [makeRow({ date: TUESDAY, time_slot: '10:00', is_available: true })]
+      const result = TrainerScheduleMapper.toDomain(rows, 't1', 'Carlos')
+
+      expect(result.weeklySchedule[1].day).toBe('Martes')
+      expect(result.weeklySchedule[1].slots).toContainEqual({ time: '10:00', available: true })
+    })
+
+    it('places a Saturday row into weeklySchedule index 5 (Sábado)', () => {
+      const rows = [makeRow({ date: SATURDAY, time_slot: '08:00', is_available: false })]
+      const result = TrainerScheduleMapper.toDomain(rows, 't1', 'Carlos')
+
+      expect(result.weeklySchedule[5].day).toBe('Sábado')
+      expect(result.weeklySchedule[5].slots).toContainEqual({ time: '08:00', available: false })
+    })
+
+    it('ignores Sunday rows', () => {
+      const rows = [makeRow({ date: SUNDAY, time_slot: '09:00', is_available: true })]
+      const result = TrainerScheduleMapper.toDomain(rows, 't1', 'Carlos')
+
+      const allSlots = result.weeklySchedule.flatMap((d) => d.slots)
+      expect(allSlots).toHaveLength(0)
+    })
+
+    it('marks a slot available if ANY row for that (day, slot) is available', () => {
+      const rows = [
+        makeRow({ date: MONDAY, time_slot: '09:00', is_available: false }),
+        makeRow({ id: 'row-2', date: MONDAY, time_slot: '09:00', is_available: true }),
+      ]
+      const result = TrainerScheduleMapper.toDomain(rows, 't1', 'Carlos')
+      const slot = result.weeklySchedule[0].slots.find((s) => s.time === '09:00')
+
+      expect(slot?.available).toBe(true)
+    })
+
+    it('keeps a slot unavailable if ALL rows for that (day, slot) are unavailable', () => {
+      const rows = [
+        makeRow({ date: MONDAY, time_slot: '09:00', is_available: false }),
+        makeRow({ id: 'row-2', date: MONDAY, time_slot: '09:00', is_available: false }),
+      ]
+      const result = TrainerScheduleMapper.toDomain(rows, 't1', 'Carlos')
+      const slot = result.weeklySchedule[0].slots.find((s) => s.time === '09:00')
+
+      expect(slot?.available).toBe(false)
+    })
+
+    it('sorts slots alphabetically within a day', () => {
+      const rows = [
+        makeRow({ date: MONDAY, time_slot: '10:00', is_available: true }),
+        makeRow({ id: 'r2', date: MONDAY, time_slot: '09:00', is_available: true }),
+        makeRow({ id: 'r3', date: MONDAY, time_slot: '11:00', is_available: true }),
+      ]
+      const result = TrainerScheduleMapper.toDomain(rows, 't1', 'Carlos')
+      const times = result.weeklySchedule[0].slots.map((s) => s.time)
+
+      expect(times).toEqual(['09:00', '10:00', '11:00'])
+    })
+
+    it('leaves other days empty when rows only cover one day', () => {
+      const rows = [makeRow({ date: MONDAY, time_slot: '09:00' })]
+      const result = TrainerScheduleMapper.toDomain(rows, 't1', 'Carlos')
+
+      // Tue–Sat should have no slots
+      for (let i = 1; i <= 5; i++) {
+        expect(result.weeklySchedule[i].slots).toHaveLength(0)
+      }
+    })
+  })
+
+  describe('toAvailableSlots', () => {
+    it('returns only is_available=true time_slots', () => {
+      const rows = [
+        makeRow({ time_slot: '09:00', is_available: true }),
+        makeRow({ id: 'r2', time_slot: '10:00', is_available: false }),
+        makeRow({ id: 'r3', time_slot: '11:00', is_available: true }),
+      ]
+      const result = TrainerScheduleMapper.toAvailableSlots(rows)
+
+      expect(result).toEqual(['09:00', '11:00'])
+    })
+
+    it('returns an empty array when no rows are available', () => {
+      const rows = [
+        makeRow({ time_slot: '09:00', is_available: false }),
+        makeRow({ id: 'r2', time_slot: '10:00', is_available: false }),
+      ]
+      const result = TrainerScheduleMapper.toAvailableSlots(rows)
+
+      expect(result).toEqual([])
+    })
+
+    it('returns an empty array for empty input', () => {
+      expect(TrainerScheduleMapper.toAvailableSlots([])).toEqual([])
+    })
+
+    it('sorts the returned slots alphabetically', () => {
+      const rows = [
+        makeRow({ time_slot: '11:00', is_available: true }),
+        makeRow({ id: 'r2', time_slot: '09:00', is_available: true }),
+        makeRow({ id: 'r3', time_slot: '10:00', is_available: true }),
+      ]
+      const result = TrainerScheduleMapper.toAvailableSlots(rows)
+
+      expect(result).toEqual(['09:00', '10:00', '11:00'])
+    })
+  })
+
+  describe('toInsertRows', () => {
+    const schedule = TrainerScheduleMapper.toDomain(
+      [
+        makeRow({ date: MONDAY, time_slot: '09:00', is_available: true }),
+        makeRow({ id: 'r2', date: MONDAY, time_slot: '10:00', is_available: false }),
+        makeRow({ id: 'r3', date: SATURDAY, time_slot: '08:00', is_available: true }),
+      ],
+      'uuid-trainer-1',
+      'Carlos',
+    )
+
+    it('produces rows for a week starting on the given Monday', () => {
+      const weekStart = new Date('2026-05-25') // a Monday
+      const rows = TrainerScheduleMapper.toInsertRows(schedule, weekStart)
+
+      const dates = rows.map((r) => r.date)
+      expect(dates).toContain('2026-05-25') // Monday
+      expect(dates).toContain('2026-05-30') // Saturday
+    })
+
+    it('sets trainer_id from the schedule on every row', () => {
+      const rows = TrainerScheduleMapper.toInsertRows(schedule, new Date('2026-05-25'))
+
+      rows.forEach((r) => expect(r.trainer_id).toBe('uuid-trainer-1'))
+    })
+
+    it('preserves is_available values', () => {
+      const rows = TrainerScheduleMapper.toInsertRows(schedule, new Date('2026-05-25'))
+      const mondaySlots = rows.filter((r) => r.date === '2026-05-25')
+      const slot09 = mondaySlots.find((r) => r.time_slot === '09:00')
+      const slot10 = mondaySlots.find((r) => r.time_slot === '10:00')
+
+      expect(slot09?.is_available).toBe(true)
+      expect(slot10?.is_available).toBe(false)
+    })
+
+    it('does not produce rows for days with no slots', () => {
+      // Days 1–4 (Tue–Fri) have no slots in the schedule
+      const rows = TrainerScheduleMapper.toInsertRows(schedule, new Date('2026-05-25'))
+      const tuesdayRows = rows.filter((r) => r.date === '2026-05-26')
+
+      expect(tuesdayRows).toHaveLength(0)
+    })
+
+    it('does not include id or created_at in insert rows', () => {
+      const rows = TrainerScheduleMapper.toInsertRows(schedule, new Date('2026-05-25'))
+
+      rows.forEach((r) => {
+        expect((r as Record<string, unknown>)['id']).toBeUndefined()
+        expect((r as Record<string, unknown>)['created_at']).toBeUndefined()
+      })
+    })
+  })
+
+  describe('dayIndexFromDate', () => {
+    it('returns 0 for Monday', () => {
+      expect(TrainerScheduleMapper.dayIndexFromDate(new Date('2026-05-11'))).toBe(0)
+    })
+
+    it('returns 5 for Saturday', () => {
+      expect(TrainerScheduleMapper.dayIndexFromDate(new Date('2026-05-16'))).toBe(5)
+    })
+
+    it('returns -1 for Sunday', () => {
+      expect(TrainerScheduleMapper.dayIndexFromDate(new Date('2026-05-17'))).toBe(-1)
+    })
+  })
+
+  describe('dayName', () => {
+    it('returns the correct Spanish day name for each index', () => {
+      expect(TrainerScheduleMapper.dayName(0)).toBe('Lunes')
+      expect(TrainerScheduleMapper.dayName(1)).toBe('Martes')
+      expect(TrainerScheduleMapper.dayName(2)).toBe('Miércoles')
+      expect(TrainerScheduleMapper.dayName(3)).toBe('Jueves')
+      expect(TrainerScheduleMapper.dayName(4)).toBe('Viernes')
+      expect(TrainerScheduleMapper.dayName(5)).toBe('Sábado')
+    })
+
+    it('returns empty string for out-of-range index', () => {
+      expect(TrainerScheduleMapper.dayName(6)).toBe('')
+      expect(TrainerScheduleMapper.dayName(-1)).toBe('')
+    })
+  })
+})

--- a/tests/unit/core/mappers/TrainerScheduleMapper.test.ts
+++ b/tests/unit/core/mappers/TrainerScheduleMapper.test.ts
@@ -206,8 +206,8 @@ describe('TrainerScheduleMapper', () => {
       const rows = TrainerScheduleMapper.toInsertRows(schedule, new Date('2026-05-25'))
 
       rows.forEach((r) => {
-        expect((r as Record<string, unknown>)['id']).toBeUndefined()
-        expect((r as Record<string, unknown>)['created_at']).toBeUndefined()
+        expect((r as unknown as Record<string, unknown>)['id']).toBeUndefined()
+        expect((r as unknown as Record<string, unknown>)['created_at']).toBeUndefined()
       })
     })
   })


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Add `src/core/types/supabase.ts` with all Supabase row types (`BookingRow`, `TrainerRow`, `TrainerScheduleRow`, `UserProfileRow`, `ProgramRow`) and their `Insert` variants (omitting server-generated `id`/`created_at`)
- Add `src/core/mappers/` with five mapper classes that translate between Supabase snake_case rows and domain camelCase entities: `BookingMapper`, `TrainerMapper`, `TrainerScheduleMapper`, `ProgramMapper`, `ClientMapper`
- Export all mappers from `src/core/mappers/index.ts`

## Why

Before implementing `SupabaseDataService`, the DTO/Mapper layer needs to exist as a separate concern — following the Repository Pattern from the MVVM architecture guide. Without mappers, transformation logic would end up buried inside `SupabaseDataService` (mixing HTTP + mapping responsibilities).

Key structural note in `TrainerScheduleMapper`: the domain uses a weekly pattern (Mon–Sat indexed 0–5) while Supabase stores one row per slot per specific calendar date. The mapper handles both directions (`toDomain`, `toAvailableSlots`, `toInsertRows`).

## Test plan

- [ ] `npm run build` passes with no new TypeScript errors
- [ ] Unit tests for each mapper: `tests/unit/core/mappers/`
- [ ] Verify `BookingMapper.toDomain` correctly parses `date` string → `Date` object
- [ ] Verify `TrainerScheduleMapper.toInsertRows` expands a weekly schedule to the correct Mon–Sat dates

https://claude.ai/code/session_01QLt6xhMZPQZntXLtbSSszH
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLt6xhMZPQZntXLtbSSszH)_