### PR TITLE
feat: SupabaseDataService — full IDataService implementation with 29 tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nivel-ui",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.105.4",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "mobx": "^6.15.0",
@@ -2310,6 +2311,90 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.4.tgz",
+      "integrity": "sha512-Ejfa37M5xoIwoxVebxRahnwubPo8g22qkXQ4p50+N9MIvU9UZoN+A8dwVPtczzGf8oV/YXN80ZPxK4aWXuSN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.4.tgz",
+      "integrity": "sha512-JVNKbBft3Qkja+WlGaE026AJ2AH9K0UTsxsfvEIHgd4zFrBor4BYRCrYFrv9IDsvVqkF72wKDsODJl5GY/C4tA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.2.tgz",
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.4.tgz",
+      "integrity": "sha512-SppIyLo/kTwIlz1qpv2HN1EQqBg0GVktrDDFsXygYROha3MgVn4rT7p5EjFHFqXQm2rdRGb/BI7bc+jr10m91w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.4.tgz",
+      "integrity": "sha512-6ov6c59+8D9h7q4M4Gy/uDJlC0Akxl9/714Y+6vJ+Sijuc16TS/p5DwhfRCLNcIhNiej1gEt+CQUwsjiPt4PxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.4.tgz",
+      "integrity": "sha512-Jx+pzMP1Whjof2PWHoVBUA75/p7PQE9CqKBzn1oXVyJDOggMLSH2OzVWwsXYaxEpdC1K/KltwmOX44nL3LHl9g==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.105.4.tgz",
+      "integrity": "sha512-cEnx+k49knU+qdIP7rXwR6fqEXPHZs+74xFK1R0S8MgQ7v9tbePVdGxvO03n3bPympMdJWVLadARBfU4TgNHCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.105.4",
+        "@supabase/functions-js": "2.105.4",
+        "@supabase/postgrest-js": "2.105.4",
+        "@supabase/realtime-js": "2.105.4",
+        "@supabase/storage-js": "2.105.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -5784,6 +5869,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.105.4",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "mobx": "^6.15.0",
@@ -35,6 +36,7 @@
     "react-dom": "19.2.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.50.0",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
@@ -51,7 +53,6 @@
     "jsdom": "^26.1.0",
     "tailwindcss": "^4",
     "typescript": "^5",
-    "vitest": "^3.1.1",
-    "@playwright/test": "^1.50.0"
+    "vitest": "^3.1.1"
   }
 }

--- a/src/core/services/SupabaseDataService.ts
+++ b/src/core/services/SupabaseDataService.ts
@@ -1,0 +1,306 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { addWeeks, format, startOfWeek } from 'date-fns';
+import { Booking, Client, Program, Trainer, TrainerSchedule } from '../types';
+import {
+  IBookingRepository,
+  IClientRepository,
+  IDataService,
+  IProgramRepository,
+  ITrainerRepository,
+} from '../repositories';
+import {
+  BookingMapper,
+  ClientMapper,
+  ProgramMapper,
+  TrainerMapper,
+  TrainerScheduleMapper,
+} from '../mappers';
+import { BookingRow, ProgramRow, TrainerRow, TrainerScheduleRow, UserProfileRow } from '../types/supabase';
+
+// Number of rolling calendar weeks written on each saveSchedule() call
+const SCHEDULE_WEEKS = 4;
+
+export class SupabaseClientRepository implements IClientRepository {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async getAll(): Promise<Client[]> {
+    const { data, error } = await this.client
+      .from('user_profiles')
+      .select('*')
+      .eq('role', 'client');
+    if (error) throw new Error(error.message);
+    return (data as UserProfileRow[]).map((row) =>
+      ClientMapper.toDomain(row, row.email ?? '', row.phone ?? ''),
+    );
+  }
+
+  async getById(id: string): Promise<Client | null> {
+    const { data, error } = await this.client
+      .from('user_profiles')
+      .select('*')
+      .eq('id', id)
+      .single();
+    if (error) return null;
+    const row = data as UserProfileRow;
+    return ClientMapper.toDomain(row, row.email ?? '', row.phone ?? '');
+  }
+
+  async getByEmail(email: string): Promise<Client | null> {
+    const { data, error } = await this.client
+      .from('user_profiles')
+      .select('*')
+      .eq('email', email)
+      .single();
+    if (error) return null;
+    const row = data as UserProfileRow;
+    return ClientMapper.toDomain(row, row.email ?? '', row.phone ?? '');
+  }
+
+  async save(client: Client): Promise<void> {
+    const row = {
+      id: client.id,
+      role: 'client' as const,
+      full_name: client.name,
+      email: client.email,
+      phone: client.phone,
+    };
+    const { error } = await this.client.from('user_profiles').upsert(row);
+    if (error) throw new Error(error.message);
+  }
+
+  async delete(id: string): Promise<void> {
+    const { error } = await this.client
+      .from('user_profiles')
+      .delete()
+      .eq('id', id);
+    if (error) throw new Error(error.message);
+  }
+}
+
+export class SupabaseTrainerRepository implements ITrainerRepository {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async getAll(): Promise<Trainer[]> {
+    const today = format(new Date(), 'yyyy-MM-dd');
+    const [trainersResult, scheduleResult] = await Promise.all([
+      this.client.from('trainers').select('*').eq('is_active', true),
+      this.client
+        .from('trainer_schedules')
+        .select('*')
+        .eq('date', today)
+        .eq('is_available', true),
+    ]);
+    if (trainersResult.error) throw new Error(trainersResult.error.message);
+    if (scheduleResult.error) throw new Error(scheduleResult.error.message);
+
+    const slotsByTrainer = new Map<string, string[]>();
+    for (const row of scheduleResult.data as TrainerScheduleRow[]) {
+      const slots = slotsByTrainer.get(row.trainer_id) ?? [];
+      slots.push(row.time_slot);
+      slotsByTrainer.set(row.trainer_id, slots);
+    }
+
+    return (trainersResult.data as TrainerRow[]).map((row) =>
+      TrainerMapper.toDomain(row, (slotsByTrainer.get(row.id) ?? []).sort()),
+    );
+  }
+
+  async getById(id: string): Promise<Trainer | null> {
+    const today = format(new Date(), 'yyyy-MM-dd');
+    const [trainerResult, scheduleResult] = await Promise.all([
+      this.client.from('trainers').select('*').eq('id', id).single(),
+      this.client
+        .from('trainer_schedules')
+        .select('*')
+        .eq('trainer_id', id)
+        .eq('date', today)
+        .eq('is_available', true),
+    ]);
+    if (trainerResult.error) return null;
+    const slots = (scheduleResult.data as TrainerScheduleRow[] | null)?.map(
+      (r) => r.time_slot,
+    ) ?? [];
+    return TrainerMapper.toDomain(trainerResult.data as TrainerRow, slots.sort());
+  }
+
+  async save(trainer: Trainer): Promise<void> {
+    const row = { id: trainer.id, name: trainer.name, is_active: true };
+    const { error } = await this.client.from('trainers').upsert(row);
+    if (error) throw new Error(error.message);
+  }
+
+  async saveSchedule(schedule: TrainerSchedule): Promise<void> {
+    const weekStart = startOfWeek(new Date(), { weekStartsOn: 1 });
+    const rows = Array.from({ length: SCHEDULE_WEEKS }, (_, i) =>
+      TrainerScheduleMapper.toInsertRows(schedule, addWeeks(weekStart, i)),
+    ).flat();
+
+    const { error } = await this.client
+      .from('trainer_schedules')
+      .upsert(rows, { onConflict: 'trainer_id,date,time_slot' });
+    if (error) throw new Error(error.message);
+  }
+
+  async getSchedule(trainerId: string): Promise<TrainerSchedule | null> {
+    const [scheduleResult, trainerResult] = await Promise.all([
+      this.client
+        .from('trainer_schedules')
+        .select('*')
+        .eq('trainer_id', trainerId),
+      this.client.from('trainers').select('name').eq('id', trainerId).single(),
+    ]);
+    if (scheduleResult.error) throw new Error(scheduleResult.error.message);
+
+    const rows = scheduleResult.data as TrainerScheduleRow[];
+    if (rows.length === 0) return null;
+
+    const trainerName = (trainerResult.data as Pick<TrainerRow, 'name'> | null)?.name ?? '';
+    return TrainerScheduleMapper.toDomain(rows, trainerId, trainerName);
+  }
+}
+
+export class SupabaseBookingRepository implements IBookingRepository {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async getAll(): Promise<Booking[]> {
+    const { data, error } = await this.client.from('bookings').select('*');
+    if (error) throw new Error(error.message);
+    return (data as BookingRow[]).map(BookingMapper.toDomain);
+  }
+
+  async getById(id: string): Promise<Booking | null> {
+    const { data, error } = await this.client
+      .from('bookings')
+      .select('*')
+      .eq('id', id)
+      .single();
+    if (error) return null;
+    return BookingMapper.toDomain(data as BookingRow);
+  }
+
+  async getByDate(date: Date): Promise<Booking[]> {
+    const { data, error } = await this.client
+      .from('bookings')
+      .select('*')
+      .eq('date', format(date, 'yyyy-MM-dd'));
+    if (error) throw new Error(error.message);
+    return (data as BookingRow[]).map(BookingMapper.toDomain);
+  }
+
+  async getByTrainer(trainerId: string): Promise<Booking[]> {
+    const { data, error } = await this.client
+      .from('bookings')
+      .select('*')
+      .eq('trainer_id', trainerId);
+    if (error) throw new Error(error.message);
+    return (data as BookingRow[]).map(BookingMapper.toDomain);
+  }
+
+  async save(booking: Booking): Promise<void> {
+    const { id, ...rest } = booking;
+    const row = { id, ...BookingMapper.toInsert(rest) };
+    const { error } = await this.client.from('bookings').upsert(row);
+    if (error) throw new Error(error.message);
+  }
+
+  async update(id: string, booking: Partial<Booking>): Promise<void> {
+    const updates: Record<string, unknown> = {};
+    if (booking.clientId   !== undefined) updates['client_id']        = booking.clientId;
+    if (booking.trainerId  !== undefined) updates['trainer_id']       = booking.trainerId;
+    if (booking.trainerName !== undefined) updates['trainer_name']    = booking.trainerName;
+    if (booking.date       !== undefined) updates['date']             = format(booking.date, 'yyyy-MM-dd');
+    if (booking.time       !== undefined) updates['time_slot']        = booking.time;
+    if (booking.duration   !== undefined) updates['duration_minutes'] = booking.duration;
+    if (booking.zone       !== undefined) updates['zone']             = booking.zone;
+    if (booking.status     !== undefined) updates['status']           = booking.status;
+
+    const { error } = await this.client
+      .from('bookings')
+      .update(updates)
+      .eq('id', id);
+    if (error) throw new Error(error.message);
+  }
+
+  async delete(id: string): Promise<void> {
+    const { error } = await this.client
+      .from('bookings')
+      .delete()
+      .eq('id', id);
+    if (error) throw new Error(error.message);
+  }
+}
+
+export class SupabaseProgramRepository implements IProgramRepository {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async getAll(): Promise<Program[]> {
+    const { data, error } = await this.client.from('programs').select('*');
+    if (error) throw new Error(error.message);
+    return (data as ProgramRow[]).map(ProgramMapper.toDomain);
+  }
+
+  async getById(id: string): Promise<Program | null> {
+    const { data, error } = await this.client
+      .from('programs')
+      .select('*')
+      .eq('id', id)
+      .single();
+    if (error) return null;
+    return ProgramMapper.toDomain(data as ProgramRow);
+  }
+
+  async getByTrainer(trainerId: string): Promise<Program[]> {
+    const { data, error } = await this.client
+      .from('programs')
+      .select('*')
+      .eq('trainer_id', trainerId);
+    if (error) throw new Error(error.message);
+    return (data as ProgramRow[]).map(ProgramMapper.toDomain);
+  }
+
+  async getByClient(clientId: string): Promise<Program[]> {
+    const { data, error } = await this.client
+      .from('programs')
+      .select('*')
+      .contains('client_ids', [clientId]);
+    if (error) throw new Error(error.message);
+    return (data as ProgramRow[]).map(ProgramMapper.toDomain);
+  }
+
+  async save(program: Program): Promise<void> {
+    const { id, ...rest } = program;
+    const row = { id, ...ProgramMapper.toInsert(rest) };
+    const { error } = await this.client.from('programs').upsert(row);
+    if (error) throw new Error(error.message);
+  }
+
+  async delete(id: string): Promise<void> {
+    const { error } = await this.client
+      .from('programs')
+      .delete()
+      .eq('id', id);
+    if (error) throw new Error(error.message);
+  }
+}
+
+export class SupabaseDataService implements IDataService {
+  readonly clients: IClientRepository;
+  readonly trainers: ITrainerRepository;
+  readonly bookings: IBookingRepository;
+  readonly programs: IProgramRepository;
+
+  constructor(client: SupabaseClient) {
+    this.clients = new SupabaseClientRepository(client);
+    this.trainers = new SupabaseTrainerRepository(client);
+    this.bookings = new SupabaseBookingRepository(client);
+    this.programs = new SupabaseProgramRepository(client);
+  }
+
+  async initialize(): Promise<void> {
+    // Schema and seed data are managed via Supabase migrations — no client-side setup needed.
+  }
+
+  async clear(): Promise<void> {
+    // No-op: clearing remote data is a destructive operation managed outside the client.
+  }
+}

--- a/src/core/types/supabase.ts
+++ b/src/core/types/supabase.ts
@@ -39,6 +39,8 @@ export interface UserProfileRow {
   id: string;               // UUID, PK = auth.users.id
   role: UserRole;
   full_name: string | null;
+  email: string | null;     // Denormalized from auth.users for client-side reads
+  phone: string | null;     // Denormalized from auth.users for client-side reads
   created_at: string;
 }
 

--- a/tests/unit/core/mappers/ClientMapper.test.ts
+++ b/tests/unit/core/mappers/ClientMapper.test.ts
@@ -6,6 +6,8 @@ const baseRow: UserProfileRow = {
   id: 'uuid-client-1',
   role: 'client',
   full_name: 'Alice García',
+  email: 'alice@gym.com',
+  phone: null,
   created_at: '2026-01-15T10:00:00Z',
 }
 

--- a/tests/unit/core/services/SupabaseDataService.test.ts
+++ b/tests/unit/core/services/SupabaseDataService.test.ts
@@ -1,0 +1,549 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  SupabaseBookingRepository,
+  SupabaseClientRepository,
+  SupabaseProgramRepository,
+  SupabaseTrainerRepository,
+  SupabaseDataService,
+} from '@/core/services/SupabaseDataService';
+import { BookingRow, ProgramRow, TrainerRow, TrainerScheduleRow, UserProfileRow } from '@/core/types/supabase';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a Supabase query-builder mock.
+ *
+ * The builder is thenable so `await chain.eq(...)` resolves to `result`.
+ * Individual terminal methods (.single, .upsert) can be overridden per test.
+ */
+function makeBuilder(result: { data: unknown; error: { message: string } | null }) {
+  const builder: Record<string, unknown> = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(result),
+    upsert: vi.fn().mockResolvedValue({ data: null, error: null }),
+    update: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    contains: vi.fn().mockReturnThis(),
+    // Makes the chain itself awaitable (Supabase v2 PostgrestBuilder pattern)
+    then: (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+      Promise.resolve(result).then(resolve, reject),
+  };
+  return builder;
+}
+
+function makeClient(builder: ReturnType<typeof makeBuilder>) {
+  return { from: vi.fn().mockReturnValue(builder) } as unknown as SupabaseClient;
+}
+
+// ---------------------------------------------------------------------------
+// Row fixtures
+// ---------------------------------------------------------------------------
+
+const bookingRow: BookingRow = {
+  id: 'b1',
+  client_id: 'c1',
+  trainer_id: 't1',
+  trainer_name: 'Diego Lamas',
+  date: '2026-05-11',
+  time_slot: '09:00',
+  duration_minutes: 60,
+  zone: 'gym',
+  status: 'confirmed',
+  created_at: '2026-05-01T00:00:00Z',
+};
+
+const profileRow: UserProfileRow = {
+  id: 'c1',
+  role: 'client',
+  full_name: 'María González',
+  email: 'maria@example.com',
+  phone: '+34 611 000 001',
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+const trainerRow: TrainerRow = {
+  id: 't1',
+  user_id: 'u1',
+  name: 'Diego Lamas',
+  email: 'diego@example.com',
+  specialization: null,
+  is_active: true,
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+const scheduleRow: TrainerScheduleRow = {
+  id: 's1',
+  trainer_id: 't1',
+  date: '2026-05-11',
+  time_slot: '09:00',
+  is_available: true,
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+const programRow: ProgramRow = {
+  id: 'p1',
+  name: 'Programa Fuerza',
+  description: 'Desc',
+  trainer_id: 't1',
+  client_ids: ['c1'],
+  start_date: '2026-01-01',
+  end_date: '2026-06-30',
+  total_sessions: 20,
+  used_sessions: 5,
+  status: 'active',
+  previous_program_id: null,
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+// ---------------------------------------------------------------------------
+// SupabaseBookingRepository
+// ---------------------------------------------------------------------------
+
+describe('SupabaseBookingRepository', () => {
+  describe('getAll', () => {
+    it('queries the bookings table and maps rows to domain Bookings', async () => {
+      const builder = makeBuilder({ data: [bookingRow], error: null });
+      const client = makeClient(builder);
+      const repo = new SupabaseBookingRepository(client);
+
+      const result = await repo.getAll();
+
+      expect(client.from).toHaveBeenCalledWith('bookings');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('b1');
+      expect(result[0].clientId).toBe('c1');
+      expect(result[0].time).toBe('09:00');
+      expect(result[0].duration).toBe(60);
+      expect(result[0].date).toBeInstanceOf(Date);
+    });
+
+    it('throws when Supabase returns an error', async () => {
+      const builder = makeBuilder({ data: null, error: { message: 'DB error' } });
+      const client = makeClient(builder);
+      const repo = new SupabaseBookingRepository(client);
+
+      await expect(repo.getAll()).rejects.toThrow('DB error');
+    });
+  });
+
+  describe('getByDate', () => {
+    it('filters by formatted date string', async () => {
+      const builder = makeBuilder({ data: [bookingRow], error: null });
+      const client = makeClient(builder);
+      const repo = new SupabaseBookingRepository(client);
+
+      const date = new Date('2026-05-11');
+      await repo.getByDate(date);
+
+      expect(builder.eq).toHaveBeenCalledWith('date', '2026-05-11');
+    });
+  });
+
+  describe('getById', () => {
+    it('returns null when Supabase returns an error (not found)', async () => {
+      const builder = makeBuilder({ data: null, error: { message: 'not found' } });
+      const client = makeClient(builder);
+      const repo = new SupabaseBookingRepository(client);
+
+      const result = await repo.getById('unknown');
+      expect(result).toBeNull();
+    });
+
+    it('returns a mapped Booking when found', async () => {
+      const builder = makeBuilder({ data: bookingRow, error: null });
+      const client = makeClient(builder);
+      const repo = new SupabaseBookingRepository(client);
+
+      const result = await repo.getById('b1');
+      expect(result?.id).toBe('b1');
+    });
+  });
+
+  describe('getByTrainer', () => {
+    it('filters by trainer_id', async () => {
+      const builder = makeBuilder({ data: [bookingRow], error: null });
+      const client = makeClient(builder);
+      const repo = new SupabaseBookingRepository(client);
+
+      await repo.getByTrainer('t1');
+
+      expect(builder.eq).toHaveBeenCalledWith('trainer_id', 't1');
+    });
+  });
+
+  describe('save', () => {
+    it('upserts a row built from BookingMapper', async () => {
+      const builder = makeBuilder({ data: null, error: null });
+      const client = makeClient(builder);
+      const repo = new SupabaseBookingRepository(client);
+
+      await repo.save({
+        id: 'b1',
+        clientId: 'c1',
+        trainerId: 't1',
+        trainerName: 'Diego',
+        date: new Date('2026-05-11'),
+        time: '09:00',
+        duration: 60,
+        zone: 'gym',
+        status: 'confirmed',
+      });
+
+      expect(client.from).toHaveBeenCalledWith('bookings');
+      expect(builder.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'b1', client_id: 'c1', time_slot: '09:00' }),
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('maps partial domain fields to column names and calls update', async () => {
+      const builder = makeBuilder({ data: null, error: null });
+      // update() returns the builder; the final eq() resolves via the thenable
+      (builder.update as ReturnType<typeof vi.fn>).mockReturnValue(builder);
+      const client = makeClient(builder);
+      const repo = new SupabaseBookingRepository(client);
+
+      await repo.update('b1', { status: 'cancelled', time: '10:00' });
+
+      expect(builder.update).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'cancelled', time_slot: '10:00' }),
+      );
+      expect(builder.eq).toHaveBeenCalledWith('id', 'b1');
+    });
+
+    it('does not include undefined fields in the update payload', async () => {
+      const builder = makeBuilder({ data: null, error: null });
+      (builder.update as ReturnType<typeof vi.fn>).mockReturnValue(builder);
+      const client = makeClient(builder);
+      const repo = new SupabaseBookingRepository(client);
+
+      await repo.update('b1', { status: 'cancelled' });
+
+      const [updateArg] = (builder.update as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(Object.keys(updateArg)).toEqual(['status']);
+    });
+  });
+
+  describe('delete', () => {
+    it('calls delete on the bookings table with the given id', async () => {
+      const builder = makeBuilder({ data: null, error: null });
+      (builder.delete as ReturnType<typeof vi.fn>).mockReturnValue(builder);
+      const client = makeClient(builder);
+      const repo = new SupabaseBookingRepository(client);
+
+      await repo.delete('b1');
+
+      expect(client.from).toHaveBeenCalledWith('bookings');
+      expect(builder.eq).toHaveBeenCalledWith('id', 'b1');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SupabaseClientRepository
+// ---------------------------------------------------------------------------
+
+describe('SupabaseClientRepository', () => {
+  describe('getAll', () => {
+    it('filters by role=client and maps rows to domain Clients', async () => {
+      const builder = makeBuilder({ data: [profileRow], error: null });
+      const client = makeClient(builder);
+      const repo = new SupabaseClientRepository(client);
+
+      const result = await repo.getAll();
+
+      expect(builder.eq).toHaveBeenCalledWith('role', 'client');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('c1');
+      expect(result[0].email).toBe('maria@example.com');
+      expect(result[0].name).toBe('María González');
+    });
+
+    it('falls back to email as name when full_name is null', async () => {
+      const row: UserProfileRow = { ...profileRow, full_name: null };
+      const builder = makeBuilder({ data: [row], error: null });
+      const client = makeClient(builder);
+      const repo = new SupabaseClientRepository(client);
+
+      const result = await repo.getAll();
+
+      expect(result[0].name).toBe('maria@example.com');
+    });
+  });
+
+  describe('getById', () => {
+    it('returns null on error', async () => {
+      const builder = makeBuilder({ data: null, error: { message: 'not found' } });
+      const client = makeClient(builder);
+      const repo = new SupabaseClientRepository(client);
+
+      expect(await repo.getById('unknown')).toBeNull();
+    });
+
+    it('returns a mapped Client when found', async () => {
+      const builder = makeBuilder({ data: profileRow, error: null });
+      const client = makeClient(builder);
+      const repo = new SupabaseClientRepository(client);
+
+      const result = await repo.getById('c1');
+      expect(result?.id).toBe('c1');
+      expect(result?.phone).toBe('+34 611 000 001');
+    });
+  });
+
+  describe('getByEmail', () => {
+    it('filters by email column', async () => {
+      const builder = makeBuilder({ data: profileRow, error: null });
+      const client = makeClient(builder);
+      const repo = new SupabaseClientRepository(client);
+
+      await repo.getByEmail('maria@example.com');
+
+      expect(builder.eq).toHaveBeenCalledWith('email', 'maria@example.com');
+    });
+  });
+
+  describe('save', () => {
+    it('upserts with role=client and mapped fields', async () => {
+      const builder = makeBuilder({ data: null, error: null });
+      const client = makeClient(builder);
+      const repo = new SupabaseClientRepository(client);
+
+      await repo.save({
+        id: 'c1',
+        name: 'María',
+        email: 'maria@example.com',
+        phone: '+34 000',
+        status: 'active',
+        createdAt: new Date(),
+      });
+
+      expect(builder.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'c1', role: 'client', full_name: 'María' }),
+      );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SupabaseTrainerRepository
+// ---------------------------------------------------------------------------
+
+describe('SupabaseTrainerRepository', () => {
+  describe('getAll', () => {
+    it('fetches trainers and today schedule in parallel, builds Trainer with available slots', async () => {
+      // Two separate from() calls — one for trainers, one for trainer_schedules
+      const trainersBuilder = makeBuilder({ data: [trainerRow], error: null });
+      const scheduleBuilder = makeBuilder({ data: [scheduleRow], error: null });
+
+      let call = 0;
+      const mockClient = {
+        from: vi.fn().mockImplementation(() => (call++ === 0 ? trainersBuilder : scheduleBuilder)),
+      } as unknown as SupabaseClient;
+
+      const repo = new SupabaseTrainerRepository(mockClient);
+      const result = await repo.getAll();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('t1');
+      expect(result[0].availableSlots).toContain('09:00');
+    });
+
+    it('returns trainers with empty slots when no schedule rows exist for today', async () => {
+      const trainersBuilder = makeBuilder({ data: [trainerRow], error: null });
+      const scheduleBuilder = makeBuilder({ data: [], error: null });
+
+      let call = 0;
+      const mockClient = {
+        from: vi.fn().mockImplementation(() => (call++ === 0 ? trainersBuilder : scheduleBuilder)),
+      } as unknown as SupabaseClient;
+
+      const repo = new SupabaseTrainerRepository(mockClient);
+      const result = await repo.getAll();
+
+      expect(result[0].availableSlots).toEqual([]);
+    });
+  });
+
+  describe('getSchedule', () => {
+    it('returns null when no schedule rows exist for trainer', async () => {
+      const scheduleBuilder = makeBuilder({ data: [], error: null });
+      const trainerBuilder = makeBuilder({ data: { name: 'Diego' }, error: null });
+
+      let call = 0;
+      const mockClient = {
+        from: vi.fn().mockImplementation(() => (call++ === 0 ? scheduleBuilder : trainerBuilder)),
+      } as unknown as SupabaseClient;
+
+      const repo = new SupabaseTrainerRepository(mockClient);
+      const result = await repo.getSchedule('t1');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns a TrainerSchedule built from schedule rows', async () => {
+      const scheduleBuilder = makeBuilder({ data: [scheduleRow], error: null });
+      const trainerBuilder = makeBuilder({ data: { name: 'Diego Lamas' }, error: null });
+
+      let call = 0;
+      const mockClient = {
+        from: vi.fn().mockImplementation(() => (call++ === 0 ? scheduleBuilder : trainerBuilder)),
+      } as unknown as SupabaseClient;
+
+      const repo = new SupabaseTrainerRepository(mockClient);
+      const result = await repo.getSchedule('t1');
+
+      expect(result).not.toBeNull();
+      expect(result!.trainerId).toBe('t1');
+      expect(result!.trainerName).toBe('Diego Lamas');
+    });
+  });
+
+  describe('saveSchedule', () => {
+    it('upserts rows for SCHEDULE_WEEKS calendar weeks', async () => {
+      const builder = makeBuilder({ data: null, error: null });
+      const client = makeClient(builder);
+      const repo = new SupabaseTrainerRepository(client);
+
+      const schedule = {
+        trainerId: 't1',
+        trainerName: 'Diego',
+        weeklySchedule: [
+          { day: 'Lunes', slots: [{ time: '09:00', available: true }] },
+          { day: 'Martes', slots: [] },
+          { day: 'Miércoles', slots: [] },
+          { day: 'Jueves', slots: [] },
+          { day: 'Viernes', slots: [] },
+          { day: 'Sábado', slots: [] },
+        ],
+      };
+
+      await repo.saveSchedule(schedule);
+
+      expect(builder.upsert).toHaveBeenCalledOnce();
+      const [rows] = (builder.upsert as ReturnType<typeof vi.fn>).mock.calls[0];
+      // 1 slot × 4 weeks = 4 rows
+      expect(rows).toHaveLength(4);
+      expect(rows[0].trainer_id).toBe('t1');
+      expect(rows[0].time_slot).toBe('09:00');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SupabaseProgramRepository
+// ---------------------------------------------------------------------------
+
+describe('SupabaseProgramRepository', () => {
+  describe('getAll', () => {
+    it('maps ProgramRows to domain Programs', async () => {
+      const builder = makeBuilder({ data: [programRow], error: null });
+      const client = makeClient(builder);
+      const repo = new SupabaseProgramRepository(client);
+
+      const result = await repo.getAll();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('p1');
+      expect(result[0].totalSessions).toBe(20);
+      expect(result[0].startDate).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('getByClient', () => {
+    it('uses .contains() with the clientId in an array', async () => {
+      const builder = makeBuilder({ data: [programRow], error: null });
+      const client = makeClient(builder);
+      const repo = new SupabaseProgramRepository(client);
+
+      await repo.getByClient('c1');
+
+      expect(builder.contains).toHaveBeenCalledWith('client_ids', ['c1']);
+    });
+  });
+
+  describe('getByTrainer', () => {
+    it('filters by trainer_id', async () => {
+      const builder = makeBuilder({ data: [programRow], error: null });
+      const client = makeClient(builder);
+      const repo = new SupabaseProgramRepository(client);
+
+      await repo.getByTrainer('t1');
+
+      expect(builder.eq).toHaveBeenCalledWith('trainer_id', 't1');
+    });
+  });
+
+  describe('save', () => {
+    it('upserts with both id and ProgramMapper fields', async () => {
+      const builder = makeBuilder({ data: null, error: null });
+      const client = makeClient(builder);
+      const repo = new SupabaseProgramRepository(client);
+
+      await repo.save({
+        id: 'p1',
+        name: 'Fuerza',
+        description: 'Desc',
+        trainerId: 't1',
+        clientIds: ['c1'],
+        startDate: new Date('2026-01-01'),
+        endDate: new Date('2026-06-30'),
+        totalSessions: 20,
+        usedSessions: 5,
+        status: 'active',
+      });
+
+      expect(builder.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'p1', trainer_id: 't1', total_sessions: 20 }),
+      );
+    });
+  });
+
+  describe('getById', () => {
+    it('returns null when not found', async () => {
+      const builder = makeBuilder({ data: null, error: { message: 'not found' } });
+      const client = makeClient(builder);
+      const repo = new SupabaseProgramRepository(client);
+
+      expect(await repo.getById('unknown')).toBeNull();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SupabaseDataService
+// ---------------------------------------------------------------------------
+
+describe('SupabaseDataService', () => {
+  it('exposes clients, trainers, bookings and programs repositories', () => {
+    const builder = makeBuilder({ data: [], error: null });
+    const client = makeClient(builder);
+    const service = new SupabaseDataService(client);
+
+    expect(service.clients).toBeDefined();
+    expect(service.trainers).toBeDefined();
+    expect(service.bookings).toBeDefined();
+    expect(service.programs).toBeDefined();
+  });
+
+  it('initialize() resolves without error', async () => {
+    const builder = makeBuilder({ data: [], error: null });
+    const client = makeClient(builder);
+    const service = new SupabaseDataService(client);
+
+    await expect(service.initialize()).resolves.toBeUndefined();
+  });
+
+  it('clear() resolves without error', async () => {
+    const builder = makeBuilder({ data: [], error: null });
+    const client = makeClient(builder);
+    const service = new SupabaseDataService(client);
+
+    await expect(service.clear()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `SupabaseDataService` (`src/core/services/SupabaseDataService.ts`) implementing `IDataService` using the existing mapper layer — zero changes to Models or ViewModels (OCP)
- Extends `UserProfileRow` with denormalized `email` and `phone` columns so `ClientMapper` can hydrate `Client` without requiring Supabase Auth admin API access
- Four exported repository classes (`SupabaseClientRepository`, `SupabaseTrainerRepository`, `SupabaseBookingRepository`, `SupabaseProgramRepository`) each implement their respective `I*Repository` interface

**Key design decisions:**
- `SupabaseTrainerRepository.getAll()` fetches trainers and today's schedule rows in a single `Promise.all` to avoid N+1 queries
- `saveSchedule()` upserts 4 rolling calendar weeks of schedule slots using `TrainerScheduleMapper.toInsertRows()` with `onConflict: trainer_id,date,time_slot`
- `initialize()` and `clear()` are intentional no-ops — schema and seed data are managed via Supabase SQL migrations, not client-side code
- `BookingRepository.update()` only includes defined fields in the PATCH payload, never overwriting unchanged columns

## Test plan

- [ ] 29 new unit tests in `tests/unit/core/services/SupabaseDataService.test.ts`
- [ ] All 256 tests pass: `npx vitest run`
- [ ] `tsc --noEmit` clean

https://claude.ai/code/session_01QLt6xhMZPQZntXLtbSSszH

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLt6xhMZPQZntXLtbSSszH)_