### PR TITLE
feat: AuthViewModel, SupabaseAuthService, AuthProvider and /login page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { AuthProvider } from "@/core/providers/AuthProvider";
 import { DataProvider } from "@/core/providers/DataProvider";
 import { ViewModelProvider } from "@/core/providers/ViewModelProvider";
 
@@ -29,11 +30,13 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <DataProvider>
-          <ViewModelProvider>
-            {children}
-          </ViewModelProvider>
-        </DataProvider>
+        <AuthProvider>
+          <DataProvider>
+            <ViewModelProvider>
+              {children}
+            </ViewModelProvider>
+          </DataProvider>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useState, FormEvent, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { observer } from 'mobx-react-lite';
+import { useAuthViewModel } from '@/core/providers/AuthProvider';
+
+const LoginPage = observer(() => {
+  const authVM = useAuthViewModel();
+  const router = useRouter();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  // Redirect if already authenticated
+  useEffect(() => {
+    if (!authVM.isLoading && authVM.isAuthenticated) {
+      router.replace(authVM.isTrainer ? '/trainer' : '/client');
+    }
+  }, [authVM.isAuthenticated, authVM.isLoading, authVM.isTrainer, router]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const success = await authVM.signIn(email, password);
+    if (success) {
+      router.replace(authVM.isTrainer ? '/trainer' : '/client');
+    }
+  };
+
+  if (authVM.isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="animate-pulse text-gray-400 text-sm">Cargando…</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-sm bg-white rounded-2xl shadow-sm border border-gray-100 p-8">
+        {/* Logo / title */}
+        <div className="mb-8 text-center">
+          <h1 className="text-2xl font-bold text-gray-900 tracking-tight">Nivel Gym</h1>
+          <p className="mt-1 text-sm text-gray-500">Inicia sesión para continuar</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Email */}
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+              Correo electrónico
+            </label>
+            <input
+              id="email"
+              type="email"
+              autoComplete="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm placeholder-gray-400
+                         focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent
+                         disabled:opacity-50"
+              placeholder="tu@email.com"
+              disabled={authVM.isLoading}
+            />
+          </div>
+
+          {/* Password */}
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+              Contraseña
+            </label>
+            <input
+              id="password"
+              type="password"
+              autoComplete="current-password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm placeholder-gray-400
+                         focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent
+                         disabled:opacity-50"
+              placeholder="••••••••"
+              disabled={authVM.isLoading}
+            />
+          </div>
+
+          {/* Error */}
+          {authVM.error && (
+            <p className="text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2">
+              {authVM.error}
+            </p>
+          )}
+
+          {/* Submit */}
+          <button
+            type="submit"
+            disabled={authVM.isLoading}
+            className="w-full py-2.5 px-4 bg-gray-900 text-white text-sm font-medium rounded-lg
+                       hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2
+                       focus:ring-gray-900 disabled:opacity-50 disabled:cursor-not-allowed
+                       transition-colors"
+          >
+            {authVM.isLoading ? 'Iniciando sesión…' : 'Iniciar sesión'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+});
+
+export default LoginPage;

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -52,6 +52,7 @@ const LoginPage = observer(() => {
             </label>
             <input
               id="email"
+              data-testid="login-email"
               type="email"
               autoComplete="email"
               required
@@ -72,6 +73,7 @@ const LoginPage = observer(() => {
             </label>
             <input
               id="password"
+              data-testid="login-password"
               type="password"
               autoComplete="current-password"
               required
@@ -87,13 +89,14 @@ const LoginPage = observer(() => {
 
           {/* Error */}
           {authVM.error && (
-            <p className="text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2">
+            <p data-testid="login-error" className="text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2">
               {authVM.error}
             </p>
           )}
 
           {/* Submit */}
           <button
+            data-testid="login-submit"
             type="submit"
             disabled={authVM.isLoading}
             className="w-full py-2.5 px-4 bg-gray-900 text-white text-sm font-medium rounded-lg

--- a/src/core/models/AuthModel.ts
+++ b/src/core/models/AuthModel.ts
@@ -1,0 +1,37 @@
+import { AuthUser } from '../types';
+import { AuthenticationError } from '../types/errors';
+import { IAuthService } from '../repositories/auth';
+
+export class AuthModel {
+  constructor(private readonly authService: IAuthService) {}
+
+  async signIn(email: string, password: string): Promise<AuthUser> {
+    if (!email.trim()) {
+      throw new AuthenticationError('El correo electrónico es requerido');
+    }
+    if (!password) {
+      throw new AuthenticationError('La contraseña es requerida');
+    }
+
+    try {
+      return await this.authService.signIn(email, password);
+    } catch (err) {
+      if (err instanceof AuthenticationError) throw err;
+      throw new AuthenticationError(
+        err instanceof Error ? err.message : 'Credenciales incorrectas',
+      );
+    }
+  }
+
+  async signOut(): Promise<void> {
+    await this.authService.signOut();
+  }
+
+  async getCurrentUser(): Promise<AuthUser | null> {
+    return this.authService.getCurrentUser();
+  }
+
+  onAuthStateChange(callback: (user: AuthUser | null) => void): () => void {
+    return this.authService.onAuthStateChange(callback);
+  }
+}

--- a/src/core/providers/AuthProvider.tsx
+++ b/src/core/providers/AuthProvider.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { createContext, useContext, useMemo, useEffect, ReactNode } from 'react';
+import { AuthModel } from '../models/AuthModel';
 import { AuthViewModel } from '../view-models/AuthViewModel';
 import { SupabaseAuthService } from '../services/SupabaseAuthService';
 import { NoopAuthService } from '../services/NoopAuthService';
@@ -11,10 +12,9 @@ const AuthContext = createContext<AuthViewModel | null>(null);
 export function AuthProvider({ children }: { children: ReactNode }) {
   const authVM = useMemo(() => {
     const supabase = getSupabaseBrowserClient();
-    const service = supabase
-      ? new SupabaseAuthService(supabase)
-      : new NoopAuthService();
-    return new AuthViewModel(service);
+    const service = supabase ? new SupabaseAuthService(supabase) : new NoopAuthService();
+    const model = new AuthModel(service);
+    return new AuthViewModel(model);
   }, []);
 
   useEffect(() => {

--- a/src/core/providers/AuthProvider.tsx
+++ b/src/core/providers/AuthProvider.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { createContext, useContext, useMemo, useEffect, ReactNode } from 'react';
+import { AuthViewModel } from '../view-models/AuthViewModel';
+import { SupabaseAuthService } from '../services/SupabaseAuthService';
+import { NoopAuthService } from '../services/NoopAuthService';
+import { getSupabaseBrowserClient } from '@/lib/supabase';
+
+const AuthContext = createContext<AuthViewModel | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const authVM = useMemo(() => {
+    const supabase = getSupabaseBrowserClient();
+    const service = supabase
+      ? new SupabaseAuthService(supabase)
+      : new NoopAuthService();
+    return new AuthViewModel(service);
+  }, []);
+
+  useEffect(() => {
+    authVM.initialize();
+    return () => authVM.dispose();
+  }, [authVM]);
+
+  return <AuthContext.Provider value={authVM}>{children}</AuthContext.Provider>;
+}
+
+export function useAuthViewModel(): AuthViewModel {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuthViewModel must be used within AuthProvider');
+  return ctx;
+}

--- a/src/core/repositories/auth.ts
+++ b/src/core/repositories/auth.ts
@@ -1,0 +1,8 @@
+import { AuthUser } from '../types';
+
+export interface IAuthService {
+  signIn(email: string, password: string): Promise<AuthUser>;
+  signOut(): Promise<void>;
+  getCurrentUser(): Promise<AuthUser | null>;
+  onAuthStateChange(callback: (user: AuthUser | null) => void): () => void;
+}

--- a/src/core/repositories/index.ts
+++ b/src/core/repositories/index.ts
@@ -1,4 +1,4 @@
-import { Trainer, Booking, TrainerSchedule, Client, Program } from '../types';
+import { Trainer, Booking, TrainerSchedule, Client, Program, AuthUser } from '../types';
 
 // Interfaces de repositorios para abstracción de datos
 export interface IClientRepository {
@@ -34,6 +34,13 @@ export interface IProgramRepository {
   getByClient(clientId: string): Promise<Program[]>;
   save(program: Program): Promise<void>;
   delete(id: string): Promise<void>;
+}
+
+export interface IAuthService {
+  signIn(email: string, password: string): Promise<AuthUser>;
+  signOut(): Promise<void>;
+  getCurrentUser(): Promise<AuthUser | null>;
+  onAuthStateChange(callback: (user: AuthUser | null) => void): () => void;
 }
 
 export interface IDataService {

--- a/src/core/repositories/index.ts
+++ b/src/core/repositories/index.ts
@@ -1,4 +1,4 @@
-import { Trainer, Booking, TrainerSchedule, Client, Program, AuthUser } from '../types';
+import { Trainer, Booking, TrainerSchedule, Client, Program } from '../types';
 
 // Interfaces de repositorios para abstracción de datos
 export interface IClientRepository {
@@ -34,13 +34,6 @@ export interface IProgramRepository {
   getByClient(clientId: string): Promise<Program[]>;
   save(program: Program): Promise<void>;
   delete(id: string): Promise<void>;
-}
-
-export interface IAuthService {
-  signIn(email: string, password: string): Promise<AuthUser>;
-  signOut(): Promise<void>;
-  getCurrentUser(): Promise<AuthUser | null>;
-  onAuthStateChange(callback: (user: AuthUser | null) => void): () => void;
 }
 
 export interface IDataService {

--- a/src/core/services/NoopAuthService.ts
+++ b/src/core/services/NoopAuthService.ts
@@ -1,0 +1,24 @@
+import { AuthUser } from '../types';
+import { IAuthService } from '../repositories';
+
+// Used when NEXT_PUBLIC_SUPABASE_URL is not configured (localStorage dev mode).
+// signIn always succeeds so the UI is usable without a real Supabase project.
+export class NoopAuthService implements IAuthService {
+  private user: AuthUser = { id: 'local-user', email: 'dev@nivel.gym', role: 'client' };
+
+  async signIn(_email: string, _password: string): Promise<AuthUser> {
+    return this.user;
+  }
+
+  async signOut(): Promise<void> {
+    // no-op
+  }
+
+  async getCurrentUser(): Promise<AuthUser | null> {
+    return null; // start unauthenticated so the login page is shown
+  }
+
+  onAuthStateChange(_callback: (user: AuthUser | null) => void): () => void {
+    return () => {};
+  }
+}

--- a/src/core/services/NoopAuthService.ts
+++ b/src/core/services/NoopAuthService.ts
@@ -1,5 +1,5 @@
 import { AuthUser } from '../types';
-import { IAuthService } from '../repositories';
+import { IAuthService } from '../repositories/auth';
 
 // Used when NEXT_PUBLIC_SUPABASE_URL is not configured (localStorage dev mode).
 // signIn always succeeds so the UI is usable without a real Supabase project.

--- a/src/core/services/SupabaseAuthService.ts
+++ b/src/core/services/SupabaseAuthService.ts
@@ -1,6 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { AuthUser, UserRole } from '../types';
-import { IAuthService } from '../repositories';
+import { IAuthService } from '../repositories/auth';
 
 export class SupabaseAuthService implements IAuthService {
   constructor(private readonly client: SupabaseClient) {}

--- a/src/core/services/SupabaseAuthService.ts
+++ b/src/core/services/SupabaseAuthService.ts
@@ -1,0 +1,51 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { AuthUser, UserRole } from '../types';
+import { IAuthService } from '../repositories';
+
+export class SupabaseAuthService implements IAuthService {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async signIn(email: string, password: string): Promise<AuthUser> {
+    const { data, error } = await this.client.auth.signInWithPassword({ email, password });
+    if (error) throw new Error(error.message);
+
+    const role = await this.fetchRole(data.user.id);
+    return { id: data.user.id, email: data.user.email!, role };
+  }
+
+  async signOut(): Promise<void> {
+    const { error } = await this.client.auth.signOut();
+    if (error) throw new Error(error.message);
+  }
+
+  async getCurrentUser(): Promise<AuthUser | null> {
+    const { data: { user } } = await this.client.auth.getUser();
+    if (!user) return null;
+
+    const role = await this.fetchRole(user.id);
+    return { id: user.id, email: user.email!, role };
+  }
+
+  onAuthStateChange(callback: (user: AuthUser | null) => void): () => void {
+    const { data: { subscription } } = this.client.auth.onAuthStateChange(
+      async (_event, session) => {
+        if (!session?.user) {
+          callback(null);
+          return;
+        }
+        const role = await this.fetchRole(session.user.id);
+        callback({ id: session.user.id, email: session.user.email!, role });
+      },
+    );
+    return () => subscription.unsubscribe();
+  }
+
+  private async fetchRole(userId: string): Promise<UserRole> {
+    const { data } = await this.client
+      .from('user_profiles')
+      .select('role')
+      .eq('id', userId)
+      .single();
+    return (data as { role: UserRole } | null)?.role ?? 'client';
+  }
+}

--- a/src/core/types/errors.ts
+++ b/src/core/types/errors.ts
@@ -1,5 +1,12 @@
 import { ZoneType, ZONE_CONFIG } from './index';
 
+export class AuthenticationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AuthenticationError';
+  }
+}
+
 export class BookingValidationError extends Error {
   constructor(message: string) {
     super(message);

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -1,3 +1,11 @@
+export type UserRole = 'client' | 'trainer';
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  role: UserRole;
+}
+
 export const AVAILABLE_TIME_SLOTS = [
   '06:00', '06:30', '07:00', '07:30', '08:00', '08:30',
   '09:00', '09:30', '10:00', '10:30', '11:00', '11:30',

--- a/src/core/types/supabase.ts
+++ b/src/core/types/supabase.ts
@@ -1,7 +1,7 @@
 // Row types that match exactly the Supabase PostgreSQL schema columns.
 // Used exclusively by mappers — domain code never imports these directly.
 
-export type UserRole = 'client' | 'trainer';
+import { UserRole } from '.';
 
 export interface TrainerRow {
   id: string;               // UUID, PK

--- a/src/core/view-models/AuthViewModel.ts
+++ b/src/core/view-models/AuthViewModel.ts
@@ -1,6 +1,6 @@
 import { makeAutoObservable, runInAction } from 'mobx';
 import { AuthUser } from '../types';
-import { IAuthService } from '../repositories';
+import { AuthModel } from '../models/AuthModel';
 
 export class AuthViewModel {
   currentUser: AuthUser | null = null;
@@ -9,21 +9,19 @@ export class AuthViewModel {
 
   private unsubscribe: (() => void) | null = null;
 
-  constructor(private readonly authService: IAuthService) {
+  constructor(private readonly authModel: AuthModel) {
     makeAutoObservable(this);
   }
 
   initialize(): void {
-    // Subscribe to real-time auth state changes
-    this.unsubscribe = this.authService.onAuthStateChange((user) => {
+    this.unsubscribe = this.authModel.onAuthStateChange((user) => {
       runInAction(() => {
         this.currentUser = user;
         this.isLoading = false;
       });
     });
 
-    // Also resolve current session on first load
-    this.authService.getCurrentUser().then((user) => {
+    this.authModel.getCurrentUser().then((user) => {
       runInAction(() => {
         this.currentUser = user;
         this.isLoading = false;
@@ -40,7 +38,7 @@ export class AuthViewModel {
     this.setLoading(true);
     this.clearError();
     try {
-      const user = await this.authService.signIn(email, password);
+      const user = await this.authModel.signIn(email, password);
       runInAction(() => {
         this.currentUser = user;
       });
@@ -59,7 +57,7 @@ export class AuthViewModel {
     this.setLoading(true);
     this.clearError();
     try {
-      await this.authService.signOut();
+      await this.authModel.signOut();
       runInAction(() => {
         this.currentUser = null;
       });
@@ -76,7 +74,6 @@ export class AuthViewModel {
     this.error = null;
   }
 
-  // Computed values
   get isAuthenticated(): boolean {
     return this.currentUser !== null;
   }

--- a/src/core/view-models/AuthViewModel.ts
+++ b/src/core/view-models/AuthViewModel.ts
@@ -1,0 +1,95 @@
+import { makeAutoObservable, runInAction } from 'mobx';
+import { AuthUser } from '../types';
+import { IAuthService } from '../repositories';
+
+export class AuthViewModel {
+  currentUser: AuthUser | null = null;
+  isLoading = true; // true until first auth check resolves
+  error: string | null = null;
+
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(private readonly authService: IAuthService) {
+    makeAutoObservable(this);
+  }
+
+  initialize(): void {
+    // Subscribe to real-time auth state changes
+    this.unsubscribe = this.authService.onAuthStateChange((user) => {
+      runInAction(() => {
+        this.currentUser = user;
+        this.isLoading = false;
+      });
+    });
+
+    // Also resolve current session on first load
+    this.authService.getCurrentUser().then((user) => {
+      runInAction(() => {
+        this.currentUser = user;
+        this.isLoading = false;
+      });
+    });
+  }
+
+  dispose(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+  }
+
+  async signIn(email: string, password: string): Promise<boolean> {
+    this.setLoading(true);
+    this.clearError();
+    try {
+      const user = await this.authService.signIn(email, password);
+      runInAction(() => {
+        this.currentUser = user;
+      });
+      return true;
+    } catch (err) {
+      runInAction(() => {
+        this.error = err instanceof Error ? err.message : 'Error al iniciar sesión';
+      });
+      return false;
+    } finally {
+      this.setLoading(false);
+    }
+  }
+
+  async signOut(): Promise<void> {
+    this.setLoading(true);
+    this.clearError();
+    try {
+      await this.authService.signOut();
+      runInAction(() => {
+        this.currentUser = null;
+      });
+    } catch (err) {
+      runInAction(() => {
+        this.error = err instanceof Error ? err.message : 'Error al cerrar sesión';
+      });
+    } finally {
+      this.setLoading(false);
+    }
+  }
+
+  clearError(): void {
+    this.error = null;
+  }
+
+  // Computed values
+  get isAuthenticated(): boolean {
+    return this.currentUser !== null;
+  }
+
+  get isTrainer(): boolean {
+    return this.currentUser?.role === 'trainer';
+  }
+
+  get isClient(): boolean {
+    return this.currentUser?.role === 'client';
+  }
+
+  private setLoading(loading: boolean): void {
+    this.isLoading = loading;
+  }
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,14 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+let client: SupabaseClient | null = null;
+
+export function getSupabaseBrowserClient(): SupabaseClient | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !key) return null;
+
+  if (!client) {
+    client = createClient(url, key);
+  }
+  return client;
+}

--- a/tests/unit/core/models/AuthModel.test.ts
+++ b/tests/unit/core/models/AuthModel.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AuthModel } from '@/core/models/AuthModel';
+import { IAuthService } from '@/core/repositories/auth';
+import { AuthenticationError } from '@/core/types/errors';
+import { AuthUser } from '@/core/types';
+
+const makeUser = (overrides: Partial<AuthUser> = {}): AuthUser => ({
+  id: 'user-1',
+  email: 'test@nivel.gym',
+  role: 'client',
+  ...overrides,
+});
+
+const makeMockAuthService = (): IAuthService => ({
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+  getCurrentUser: vi.fn(),
+  onAuthStateChange: vi.fn().mockReturnValue(() => {}),
+});
+
+describe('AuthModel', () => {
+  let authService: IAuthService;
+  let model: AuthModel;
+
+  beforeEach(() => {
+    authService = makeMockAuthService();
+    model = new AuthModel(authService);
+    vi.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // signIn() — input validation
+  // ---------------------------------------------------------------------------
+
+  describe('signIn() — input validation', () => {
+    it('throws AuthenticationError when email is empty', async () => {
+      await expect(model.signIn('', 'secret'))
+        .rejects.toThrow(AuthenticationError);
+    });
+
+    it('throws AuthenticationError when email is only whitespace', async () => {
+      await expect(model.signIn('   ', 'secret'))
+        .rejects.toThrow(AuthenticationError);
+    });
+
+    it('throws AuthenticationError when password is empty', async () => {
+      await expect(model.signIn('test@nivel.gym', ''))
+        .rejects.toThrow(AuthenticationError);
+    });
+
+    it('does not call authService when validation fails', async () => {
+      await model.signIn('', 'x').catch(() => {});
+      expect(authService.signIn).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // signIn() — service delegation
+  // ---------------------------------------------------------------------------
+
+  describe('signIn() — service delegation', () => {
+    it('delegates to authService.signIn with the given credentials', async () => {
+      vi.mocked(authService.signIn).mockResolvedValue(makeUser());
+
+      await model.signIn('test@nivel.gym', 'secret');
+
+      expect(authService.signIn).toHaveBeenCalledWith('test@nivel.gym', 'secret');
+    });
+
+    it('returns the AuthUser from the service on success', async () => {
+      const user = makeUser({ role: 'trainer' });
+      vi.mocked(authService.signIn).mockResolvedValue(user);
+
+      const result = await model.signIn('test@nivel.gym', 'secret');
+
+      expect(result).toEqual(user);
+    });
+
+    it('wraps service errors as AuthenticationError', async () => {
+      vi.mocked(authService.signIn).mockRejectedValue(new Error('Invalid credentials'));
+
+      await expect(model.signIn('test@nivel.gym', 'secret'))
+        .rejects.toThrow(AuthenticationError);
+    });
+
+    it('preserves the original error message in the AuthenticationError', async () => {
+      vi.mocked(authService.signIn).mockRejectedValue(new Error('Email not confirmed'));
+
+      await expect(model.signIn('test@nivel.gym', 'secret'))
+        .rejects.toThrow('Email not confirmed');
+    });
+
+    it('does not double-wrap an AuthenticationError thrown by the service', async () => {
+      const original = new AuthenticationError('Credenciales incorrectas');
+      vi.mocked(authService.signIn).mockRejectedValue(original);
+
+      await expect(model.signIn('test@nivel.gym', 'secret'))
+        .rejects.toThrow('Credenciales incorrectas');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // signOut()
+  // ---------------------------------------------------------------------------
+
+  describe('signOut()', () => {
+    it('delegates to authService.signOut', async () => {
+      vi.mocked(authService.signOut).mockResolvedValue();
+
+      await model.signOut();
+
+      expect(authService.signOut).toHaveBeenCalledOnce();
+    });
+
+    it('propagates errors from authService.signOut', async () => {
+      vi.mocked(authService.signOut).mockRejectedValue(new Error('Network error'));
+
+      await expect(model.signOut()).rejects.toThrow('Network error');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getCurrentUser()
+  // ---------------------------------------------------------------------------
+
+  describe('getCurrentUser()', () => {
+    it('returns null when no session exists', async () => {
+      vi.mocked(authService.getCurrentUser).mockResolvedValue(null);
+
+      expect(await model.getCurrentUser()).toBeNull();
+    });
+
+    it('returns the current AuthUser when a session exists', async () => {
+      const user = makeUser();
+      vi.mocked(authService.getCurrentUser).mockResolvedValue(user);
+
+      expect(await model.getCurrentUser()).toEqual(user);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // onAuthStateChange()
+  // ---------------------------------------------------------------------------
+
+  describe('onAuthStateChange()', () => {
+    it('delegates to authService and returns the unsubscribe function', () => {
+      const unsubscribe = vi.fn();
+      vi.mocked(authService.onAuthStateChange).mockReturnValue(unsubscribe);
+
+      const returned = model.onAuthStateChange(vi.fn());
+
+      expect(authService.onAuthStateChange).toHaveBeenCalledOnce();
+      expect(returned).toBe(unsubscribe);
+    });
+
+    it('passes the callback through to authService', () => {
+      const callback = vi.fn();
+      model.onAuthStateChange(callback);
+
+      expect(authService.onAuthStateChange).toHaveBeenCalledWith(callback);
+    });
+  });
+});

--- a/tests/unit/core/services/NoopAuthService.test.ts
+++ b/tests/unit/core/services/NoopAuthService.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NoopAuthService } from '@/core/services/NoopAuthService';
+
+describe('NoopAuthService', () => {
+  describe('signIn()', () => {
+    it('always resolves to an AuthUser regardless of credentials', async () => {
+      const service = new NoopAuthService();
+      const result = await service.signIn('anyone@email.com', 'anypassword');
+
+      expect(result).toMatchObject({ id: expect.any(String), email: expect.any(String) });
+    });
+
+    it('returns an AuthUser with a valid role', async () => {
+      const service = new NoopAuthService();
+      const result = await service.signIn('x@x.com', 'x');
+
+      expect(['client', 'trainer']).toContain(result.role);
+    });
+
+    it('never rejects', async () => {
+      const service = new NoopAuthService();
+      await expect(service.signIn('', '')).resolves.toBeDefined();
+    });
+  });
+
+  describe('signOut()', () => {
+    it('resolves without error', async () => {
+      const service = new NoopAuthService();
+      await expect(service.signOut()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getCurrentUser()', () => {
+    it('returns null so the login page is shown on first load', async () => {
+      const service = new NoopAuthService();
+      expect(await service.getCurrentUser()).toBeNull();
+    });
+  });
+
+  describe('onAuthStateChange()', () => {
+    it('returns a function (unsubscribe)', () => {
+      const service = new NoopAuthService();
+      const unsubscribe = service.onAuthStateChange(vi.fn());
+      expect(typeof unsubscribe).toBe('function');
+    });
+
+    it('unsubscribe does not throw', () => {
+      const service = new NoopAuthService();
+      const unsubscribe = service.onAuthStateChange(vi.fn());
+      expect(() => unsubscribe()).not.toThrow();
+    });
+
+    it('never calls the callback (no auth events in noop mode)', () => {
+      const service = new NoopAuthService();
+      const callback = vi.fn();
+      service.onAuthStateChange(callback);
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/core/services/SupabaseAuthService.test.ts
+++ b/tests/unit/core/services/SupabaseAuthService.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { SupabaseAuthService } from '@/core/services/SupabaseAuthService';
+
+// ---------------------------------------------------------------------------
+// Mock factory
+// ---------------------------------------------------------------------------
+
+function makeProfileBuilder(role: string | null = 'client') {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({
+      data: role !== null ? { role } : null,
+      error: null,
+    }),
+  };
+}
+
+function makeAuthClient(overrides: {
+  signInResult?: object;
+  signOutResult?: object;
+  getUserResult?: object;
+  onAuthStateChangeResult?: object;
+  profileRole?: string | null;
+} = {}) {
+  const profileBuilder = makeProfileBuilder(overrides.profileRole ?? 'client');
+  const unsubscribeFn = vi.fn();
+
+  const client = {
+    auth: {
+      signInWithPassword: vi.fn().mockResolvedValue(
+        overrides.signInResult ?? {
+          data: { user: { id: 'u1', email: 'test@nivel.gym' } },
+          error: null,
+        },
+      ),
+      signOut: vi.fn().mockResolvedValue(overrides.signOutResult ?? { error: null }),
+      getUser: vi.fn().mockResolvedValue(
+        overrides.getUserResult ?? { data: { user: { id: 'u1', email: 'test@nivel.gym' } } },
+      ),
+      onAuthStateChange: vi.fn().mockReturnValue(
+        overrides.onAuthStateChangeResult ?? {
+          data: { subscription: { unsubscribe: unsubscribeFn } },
+        },
+      ),
+    },
+    from: vi.fn().mockReturnValue(profileBuilder),
+    _unsubscribe: unsubscribeFn,
+    _profileBuilder: profileBuilder,
+  };
+
+  return client as unknown as SupabaseClient & {
+    _unsubscribe: ReturnType<typeof vi.fn>;
+    _profileBuilder: ReturnType<typeof makeProfileBuilder>;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SupabaseAuthService', () => {
+  let client: ReturnType<typeof makeAuthClient>;
+  let service: SupabaseAuthService;
+
+  beforeEach(() => {
+    client = makeAuthClient();
+    service = new SupabaseAuthService(client);
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // signIn()
+  // -------------------------------------------------------------------------
+
+  describe('signIn()', () => {
+    it('calls signInWithPassword with the given credentials', async () => {
+      client = makeAuthClient({ profileRole: 'client' });
+      service = new SupabaseAuthService(client);
+
+      await service.signIn('test@nivel.gym', 'secret');
+
+      expect(client.auth.signInWithPassword).toHaveBeenCalledWith({
+        email: 'test@nivel.gym',
+        password: 'secret',
+      });
+    });
+
+    it('returns an AuthUser with id, email and role on success', async () => {
+      client = makeAuthClient({ profileRole: 'trainer' });
+      service = new SupabaseAuthService(client);
+
+      const result = await service.signIn('test@nivel.gym', 'secret');
+
+      expect(result).toEqual({ id: 'u1', email: 'test@nivel.gym', role: 'trainer' });
+    });
+
+    it('fetches role from user_profiles using the authenticated user id', async () => {
+      client = makeAuthClient({ profileRole: 'client' });
+      service = new SupabaseAuthService(client);
+
+      await service.signIn('test@nivel.gym', 'secret');
+
+      expect(client.from).toHaveBeenCalledWith('user_profiles');
+      expect(client._profileBuilder.eq).toHaveBeenCalledWith('id', 'u1');
+    });
+
+    it('defaults role to client when user_profiles returns no row', async () => {
+      client = makeAuthClient({ profileRole: null });
+      service = new SupabaseAuthService(client);
+
+      const result = await service.signIn('test@nivel.gym', 'secret');
+
+      expect(result.role).toBe('client');
+    });
+
+    it('throws when Supabase auth returns an error', async () => {
+      client = makeAuthClient({
+        signInResult: { data: { user: null }, error: { message: 'Invalid credentials' } },
+      });
+      service = new SupabaseAuthService(client);
+
+      await expect(service.signIn('bad@email.com', 'wrong')).rejects.toThrow('Invalid credentials');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // signOut()
+  // -------------------------------------------------------------------------
+
+  describe('signOut()', () => {
+    it('calls client.auth.signOut', async () => {
+      await service.signOut();
+      expect(client.auth.signOut).toHaveBeenCalledOnce();
+    });
+
+    it('throws when Supabase returns an error', async () => {
+      client = makeAuthClient({ signOutResult: { error: { message: 'Session expired' } } });
+      service = new SupabaseAuthService(client);
+
+      await expect(service.signOut()).rejects.toThrow('Session expired');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getCurrentUser()
+  // -------------------------------------------------------------------------
+
+  describe('getCurrentUser()', () => {
+    it('returns null when no user session exists', async () => {
+      client = makeAuthClient({ getUserResult: { data: { user: null } } });
+      service = new SupabaseAuthService(client);
+
+      expect(await service.getCurrentUser()).toBeNull();
+    });
+
+    it('returns an AuthUser with role when a session exists', async () => {
+      client = makeAuthClient({ profileRole: 'trainer' });
+      service = new SupabaseAuthService(client);
+
+      const result = await service.getCurrentUser();
+
+      expect(result).toEqual({ id: 'u1', email: 'test@nivel.gym', role: 'trainer' });
+    });
+
+    it('defaults role to client when user_profiles has no row', async () => {
+      client = makeAuthClient({ profileRole: null });
+      service = new SupabaseAuthService(client);
+
+      const result = await service.getCurrentUser();
+
+      expect(result?.role).toBe('client');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // onAuthStateChange()
+  // -------------------------------------------------------------------------
+
+  describe('onAuthStateChange()', () => {
+    it('subscribes to client.auth.onAuthStateChange', () => {
+      service.onAuthStateChange(vi.fn());
+      expect(client.auth.onAuthStateChange).toHaveBeenCalledOnce();
+    });
+
+    it('returns the Supabase unsubscribe function', () => {
+      const unsubscribe = vi.fn();
+      client = makeAuthClient({
+        onAuthStateChangeResult: {
+          data: { subscription: { unsubscribe } },
+        },
+      });
+      service = new SupabaseAuthService(client);
+
+      const returned = service.onAuthStateChange(vi.fn());
+      returned();
+
+      expect(unsubscribe).toHaveBeenCalledOnce();
+    });
+
+    it('calls callback with null when session is absent', async () => {
+      const callback = vi.fn();
+      let capturedHandler: ((event: string, session: null) => Promise<void>) | null = null;
+
+      client = makeAuthClient({
+        onAuthStateChangeResult: {
+          data: { subscription: { unsubscribe: vi.fn() } },
+        },
+      });
+      (client.auth.onAuthStateChange as ReturnType<typeof vi.fn>).mockImplementation(
+        (handler: (event: string, session: null) => Promise<void>) => {
+          capturedHandler = handler;
+          return { data: { subscription: { unsubscribe: vi.fn() } } };
+        },
+      );
+      service = new SupabaseAuthService(client);
+
+      service.onAuthStateChange(callback);
+      await capturedHandler!('SIGNED_OUT', null);
+
+      expect(callback).toHaveBeenCalledWith(null);
+    });
+
+    it('calls callback with AuthUser when session is present', async () => {
+      const callback = vi.fn();
+      let capturedHandler: ((event: string, session: object) => Promise<void>) | null = null;
+
+      const profileBuilder = makeProfileBuilder('trainer');
+      client = {
+        auth: {
+          onAuthStateChange: vi.fn().mockImplementation(
+            (handler: (event: string, session: object) => Promise<void>) => {
+              capturedHandler = handler;
+              return { data: { subscription: { unsubscribe: vi.fn() } } };
+            },
+          ),
+          signInWithPassword: vi.fn(),
+          signOut: vi.fn(),
+          getUser: vi.fn(),
+        },
+        from: vi.fn().mockReturnValue(profileBuilder),
+        _unsubscribe: vi.fn(),
+        _profileBuilder: profileBuilder,
+      } as unknown as ReturnType<typeof makeAuthClient>;
+      service = new SupabaseAuthService(client);
+
+      service.onAuthStateChange(callback);
+      await capturedHandler!('SIGNED_IN', {
+        user: { id: 'u1', email: 'test@nivel.gym' },
+      });
+
+      expect(callback).toHaveBeenCalledWith({
+        id: 'u1',
+        email: 'test@nivel.gym',
+        role: 'trainer',
+      });
+    });
+  });
+});

--- a/tests/unit/core/view-models/AuthViewModel.test.ts
+++ b/tests/unit/core/view-models/AuthViewModel.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AuthViewModel } from '@/core/view-models/AuthViewModel';
-import { IAuthService } from '@/core/repositories';
+import { AuthModel } from '@/core/models/AuthModel';
 import { AuthUser } from '@/core/types';
 
 const makeUser = (overrides: Partial<AuthUser> = {}): AuthUser => ({
@@ -10,20 +10,23 @@ const makeUser = (overrides: Partial<AuthUser> = {}): AuthUser => ({
   ...overrides,
 });
 
-const makeMockAuthService = (): IAuthService => ({
-  signIn: vi.fn(),
-  signOut: vi.fn(),
-  getCurrentUser: vi.fn(),
-  onAuthStateChange: vi.fn().mockReturnValue(() => {}),
-});
+// AuthModel is a concrete class — mock its instance methods
+function makeMockAuthModel(): AuthModel {
+  return {
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    getCurrentUser: vi.fn(),
+    onAuthStateChange: vi.fn().mockReturnValue(() => {}),
+  } as unknown as AuthModel;
+}
 
 describe('AuthViewModel', () => {
-  let authService: IAuthService;
+  let authModel: AuthModel;
   let vm: AuthViewModel;
 
   beforeEach(() => {
-    authService = makeMockAuthService();
-    vm = new AuthViewModel(authService);
+    authModel = makeMockAuthModel();
+    vm = new AuthViewModel(authModel);
     vi.clearAllMocks();
   });
 
@@ -50,16 +53,16 @@ describe('AuthViewModel', () => {
   // ---------------------------------------------------------------------------
 
   describe('initialize()', () => {
-    it('subscribes to auth state changes', () => {
-      vi.mocked(authService.getCurrentUser).mockResolvedValue(null);
+    it('subscribes to auth state changes via AuthModel', () => {
+      vi.mocked(authModel.getCurrentUser).mockResolvedValue(null);
       vm.initialize();
-      expect(authService.onAuthStateChange).toHaveBeenCalledOnce();
+      expect(authModel.onAuthStateChange).toHaveBeenCalledOnce();
     });
 
-    it('resolves currentUser from getCurrentUser() on mount', async () => {
+    it('resolves currentUser from AuthModel.getCurrentUser() on mount', async () => {
       const user = makeUser();
-      vi.mocked(authService.getCurrentUser).mockResolvedValue(user);
-      vi.mocked(authService.onAuthStateChange).mockReturnValue(() => {});
+      vi.mocked(authModel.getCurrentUser).mockResolvedValue(user);
+      vi.mocked(authModel.onAuthStateChange).mockReturnValue(() => {});
 
       vm.initialize();
       await vi.waitFor(() => expect(vm.isLoading).toBe(false));
@@ -68,7 +71,7 @@ describe('AuthViewModel', () => {
     });
 
     it('sets isLoading to false even when getCurrentUser returns null', async () => {
-      vi.mocked(authService.getCurrentUser).mockResolvedValue(null);
+      vi.mocked(authModel.getCurrentUser).mockResolvedValue(null);
 
       vm.initialize();
       await vi.waitFor(() => expect(vm.isLoading).toBe(false));
@@ -78,10 +81,10 @@ describe('AuthViewModel', () => {
 
     it('updates currentUser when onAuthStateChange fires', async () => {
       const user = makeUser();
-      vi.mocked(authService.getCurrentUser).mockResolvedValue(null);
+      vi.mocked(authModel.getCurrentUser).mockResolvedValue(null);
 
       let stateChangeCallback: ((u: AuthUser | null) => void) | null = null;
-      vi.mocked(authService.onAuthStateChange).mockImplementation((cb) => {
+      vi.mocked(authModel.onAuthStateChange).mockImplementation((cb) => {
         stateChangeCallback = cb;
         return () => {};
       });
@@ -101,8 +104,8 @@ describe('AuthViewModel', () => {
   describe('dispose()', () => {
     it('calls the unsubscribe function returned by onAuthStateChange', () => {
       const unsubscribe = vi.fn();
-      vi.mocked(authService.onAuthStateChange).mockReturnValue(unsubscribe);
-      vi.mocked(authService.getCurrentUser).mockResolvedValue(null);
+      vi.mocked(authModel.onAuthStateChange).mockReturnValue(unsubscribe);
+      vi.mocked(authModel.getCurrentUser).mockResolvedValue(null);
 
       vm.initialize();
       vm.dispose();
@@ -118,7 +121,7 @@ describe('AuthViewModel', () => {
   describe('signIn()', () => {
     it('returns true and sets currentUser on success', async () => {
       const user = makeUser();
-      vi.mocked(authService.signIn).mockResolvedValue(user);
+      vi.mocked(authModel.signIn).mockResolvedValue(user);
 
       const result = await vm.signIn('test@nivel.gym', 'secret');
 
@@ -128,33 +131,33 @@ describe('AuthViewModel', () => {
     });
 
     it('returns false and sets error on failure', async () => {
-      vi.mocked(authService.signIn).mockRejectedValue(new Error('Invalid credentials'));
+      vi.mocked(authModel.signIn).mockRejectedValue(new Error('Credenciales incorrectas'));
 
       const result = await vm.signIn('bad@email.com', 'wrong');
 
       expect(result).toBe(false);
       expect(vm.currentUser).toBeNull();
-      expect(vm.error).toBe('Invalid credentials');
+      expect(vm.error).toBe('Credenciales incorrectas');
     });
 
     it('clears a previous error before attempting sign-in', async () => {
-      vi.mocked(authService.signIn).mockRejectedValue(new Error('First error'));
+      vi.mocked(authModel.signIn).mockRejectedValue(new Error('First error'));
       await vm.signIn('a@b.com', 'x');
       expect(vm.error).toBe('First error');
 
-      vi.mocked(authService.signIn).mockResolvedValue(makeUser());
+      vi.mocked(authModel.signIn).mockResolvedValue(makeUser());
       await vm.signIn('a@b.com', 'x');
       expect(vm.error).toBeNull();
     });
 
     it('sets isLoading to false after sign-in resolves', async () => {
-      vi.mocked(authService.signIn).mockResolvedValue(makeUser());
+      vi.mocked(authModel.signIn).mockResolvedValue(makeUser());
       await vm.signIn('a@b.com', 'x');
       expect(vm.isLoading).toBe(false);
     });
 
     it('sets isLoading to false after sign-in rejects', async () => {
-      vi.mocked(authService.signIn).mockRejectedValue(new Error('fail'));
+      vi.mocked(authModel.signIn).mockRejectedValue(new Error('fail'));
       await vm.signIn('a@b.com', 'x');
       expect(vm.isLoading).toBe(false);
     });
@@ -166,23 +169,23 @@ describe('AuthViewModel', () => {
 
   describe('signOut()', () => {
     it('clears currentUser on success', async () => {
-      vi.mocked(authService.signIn).mockResolvedValue(makeUser());
+      vi.mocked(authModel.signIn).mockResolvedValue(makeUser());
       await vm.signIn('a@b.com', 'x');
 
-      vi.mocked(authService.signOut).mockResolvedValue();
+      vi.mocked(authModel.signOut).mockResolvedValue();
       await vm.signOut();
 
       expect(vm.currentUser).toBeNull();
     });
 
     it('sets error when signOut throws', async () => {
-      vi.mocked(authService.signOut).mockRejectedValue(new Error('Network error'));
+      vi.mocked(authModel.signOut).mockRejectedValue(new Error('Network error'));
       await vm.signOut();
       expect(vm.error).toBe('Network error');
     });
 
     it('sets isLoading to false after signOut', async () => {
-      vi.mocked(authService.signOut).mockResolvedValue();
+      vi.mocked(authModel.signOut).mockResolvedValue();
       await vm.signOut();
       expect(vm.isLoading).toBe(false);
     });
@@ -198,7 +201,7 @@ describe('AuthViewModel', () => {
     });
 
     it('is true after a successful signIn', async () => {
-      vi.mocked(authService.signIn).mockResolvedValue(makeUser());
+      vi.mocked(authModel.signIn).mockResolvedValue(makeUser());
       await vm.signIn('a@b.com', 'x');
       expect(vm.isAuthenticated).toBe(true);
     });
@@ -210,13 +213,13 @@ describe('AuthViewModel', () => {
     });
 
     it('is true when currentUser has role trainer', async () => {
-      vi.mocked(authService.signIn).mockResolvedValue(makeUser({ role: 'trainer' }));
+      vi.mocked(authModel.signIn).mockResolvedValue(makeUser({ role: 'trainer' }));
       await vm.signIn('a@b.com', 'x');
       expect(vm.isTrainer).toBe(true);
     });
 
     it('is false when currentUser has role client', async () => {
-      vi.mocked(authService.signIn).mockResolvedValue(makeUser({ role: 'client' }));
+      vi.mocked(authModel.signIn).mockResolvedValue(makeUser({ role: 'client' }));
       await vm.signIn('a@b.com', 'x');
       expect(vm.isTrainer).toBe(false);
     });
@@ -228,7 +231,7 @@ describe('AuthViewModel', () => {
     });
 
     it('is true when currentUser has role client', async () => {
-      vi.mocked(authService.signIn).mockResolvedValue(makeUser({ role: 'client' }));
+      vi.mocked(authModel.signIn).mockResolvedValue(makeUser({ role: 'client' }));
       await vm.signIn('a@b.com', 'x');
       expect(vm.isClient).toBe(true);
     });
@@ -240,7 +243,7 @@ describe('AuthViewModel', () => {
 
   describe('clearError()', () => {
     it('resets error to null', async () => {
-      vi.mocked(authService.signIn).mockRejectedValue(new Error('oops'));
+      vi.mocked(authModel.signIn).mockRejectedValue(new Error('oops'));
       await vm.signIn('a@b.com', 'x');
 
       vm.clearError();

--- a/tests/unit/core/view-models/AuthViewModel.test.ts
+++ b/tests/unit/core/view-models/AuthViewModel.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AuthViewModel } from '@/core/view-models/AuthViewModel';
+import { IAuthService } from '@/core/repositories';
+import { AuthUser } from '@/core/types';
+
+const makeUser = (overrides: Partial<AuthUser> = {}): AuthUser => ({
+  id: 'user-1',
+  email: 'test@nivel.gym',
+  role: 'client',
+  ...overrides,
+});
+
+const makeMockAuthService = (): IAuthService => ({
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+  getCurrentUser: vi.fn(),
+  onAuthStateChange: vi.fn().mockReturnValue(() => {}),
+});
+
+describe('AuthViewModel', () => {
+  let authService: IAuthService;
+  let vm: AuthViewModel;
+
+  beforeEach(() => {
+    authService = makeMockAuthService();
+    vm = new AuthViewModel(authService);
+    vi.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Initial state
+  // ---------------------------------------------------------------------------
+
+  describe('initial state', () => {
+    it('starts with no authenticated user', () => {
+      expect(vm.currentUser).toBeNull();
+    });
+
+    it('starts in loading state', () => {
+      expect(vm.isLoading).toBe(true);
+    });
+
+    it('starts with no error', () => {
+      expect(vm.error).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // initialize()
+  // ---------------------------------------------------------------------------
+
+  describe('initialize()', () => {
+    it('subscribes to auth state changes', () => {
+      vi.mocked(authService.getCurrentUser).mockResolvedValue(null);
+      vm.initialize();
+      expect(authService.onAuthStateChange).toHaveBeenCalledOnce();
+    });
+
+    it('resolves currentUser from getCurrentUser() on mount', async () => {
+      const user = makeUser();
+      vi.mocked(authService.getCurrentUser).mockResolvedValue(user);
+      vi.mocked(authService.onAuthStateChange).mockReturnValue(() => {});
+
+      vm.initialize();
+      await vi.waitFor(() => expect(vm.isLoading).toBe(false));
+
+      expect(vm.currentUser).toEqual(user);
+    });
+
+    it('sets isLoading to false even when getCurrentUser returns null', async () => {
+      vi.mocked(authService.getCurrentUser).mockResolvedValue(null);
+
+      vm.initialize();
+      await vi.waitFor(() => expect(vm.isLoading).toBe(false));
+
+      expect(vm.currentUser).toBeNull();
+    });
+
+    it('updates currentUser when onAuthStateChange fires', async () => {
+      const user = makeUser();
+      vi.mocked(authService.getCurrentUser).mockResolvedValue(null);
+
+      let stateChangeCallback: ((u: AuthUser | null) => void) | null = null;
+      vi.mocked(authService.onAuthStateChange).mockImplementation((cb) => {
+        stateChangeCallback = cb;
+        return () => {};
+      });
+
+      vm.initialize();
+      stateChangeCallback!(user);
+
+      expect(vm.currentUser).toEqual(user);
+      expect(vm.isLoading).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // dispose()
+  // ---------------------------------------------------------------------------
+
+  describe('dispose()', () => {
+    it('calls the unsubscribe function returned by onAuthStateChange', () => {
+      const unsubscribe = vi.fn();
+      vi.mocked(authService.onAuthStateChange).mockReturnValue(unsubscribe);
+      vi.mocked(authService.getCurrentUser).mockResolvedValue(null);
+
+      vm.initialize();
+      vm.dispose();
+
+      expect(unsubscribe).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // signIn()
+  // ---------------------------------------------------------------------------
+
+  describe('signIn()', () => {
+    it('returns true and sets currentUser on success', async () => {
+      const user = makeUser();
+      vi.mocked(authService.signIn).mockResolvedValue(user);
+
+      const result = await vm.signIn('test@nivel.gym', 'secret');
+
+      expect(result).toBe(true);
+      expect(vm.currentUser).toEqual(user);
+      expect(vm.error).toBeNull();
+    });
+
+    it('returns false and sets error on failure', async () => {
+      vi.mocked(authService.signIn).mockRejectedValue(new Error('Invalid credentials'));
+
+      const result = await vm.signIn('bad@email.com', 'wrong');
+
+      expect(result).toBe(false);
+      expect(vm.currentUser).toBeNull();
+      expect(vm.error).toBe('Invalid credentials');
+    });
+
+    it('clears a previous error before attempting sign-in', async () => {
+      vi.mocked(authService.signIn).mockRejectedValue(new Error('First error'));
+      await vm.signIn('a@b.com', 'x');
+      expect(vm.error).toBe('First error');
+
+      vi.mocked(authService.signIn).mockResolvedValue(makeUser());
+      await vm.signIn('a@b.com', 'x');
+      expect(vm.error).toBeNull();
+    });
+
+    it('sets isLoading to false after sign-in resolves', async () => {
+      vi.mocked(authService.signIn).mockResolvedValue(makeUser());
+      await vm.signIn('a@b.com', 'x');
+      expect(vm.isLoading).toBe(false);
+    });
+
+    it('sets isLoading to false after sign-in rejects', async () => {
+      vi.mocked(authService.signIn).mockRejectedValue(new Error('fail'));
+      await vm.signIn('a@b.com', 'x');
+      expect(vm.isLoading).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // signOut()
+  // ---------------------------------------------------------------------------
+
+  describe('signOut()', () => {
+    it('clears currentUser on success', async () => {
+      vi.mocked(authService.signIn).mockResolvedValue(makeUser());
+      await vm.signIn('a@b.com', 'x');
+
+      vi.mocked(authService.signOut).mockResolvedValue();
+      await vm.signOut();
+
+      expect(vm.currentUser).toBeNull();
+    });
+
+    it('sets error when signOut throws', async () => {
+      vi.mocked(authService.signOut).mockRejectedValue(new Error('Network error'));
+      await vm.signOut();
+      expect(vm.error).toBe('Network error');
+    });
+
+    it('sets isLoading to false after signOut', async () => {
+      vi.mocked(authService.signOut).mockResolvedValue();
+      await vm.signOut();
+      expect(vm.isLoading).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Computed: isAuthenticated, isTrainer, isClient
+  // ---------------------------------------------------------------------------
+
+  describe('isAuthenticated (computed)', () => {
+    it('is false when currentUser is null', () => {
+      expect(vm.isAuthenticated).toBe(false);
+    });
+
+    it('is true after a successful signIn', async () => {
+      vi.mocked(authService.signIn).mockResolvedValue(makeUser());
+      await vm.signIn('a@b.com', 'x');
+      expect(vm.isAuthenticated).toBe(true);
+    });
+  });
+
+  describe('isTrainer (computed)', () => {
+    it('is false when no user is authenticated', () => {
+      expect(vm.isTrainer).toBe(false);
+    });
+
+    it('is true when currentUser has role trainer', async () => {
+      vi.mocked(authService.signIn).mockResolvedValue(makeUser({ role: 'trainer' }));
+      await vm.signIn('a@b.com', 'x');
+      expect(vm.isTrainer).toBe(true);
+    });
+
+    it('is false when currentUser has role client', async () => {
+      vi.mocked(authService.signIn).mockResolvedValue(makeUser({ role: 'client' }));
+      await vm.signIn('a@b.com', 'x');
+      expect(vm.isTrainer).toBe(false);
+    });
+  });
+
+  describe('isClient (computed)', () => {
+    it('is false when no user is authenticated', () => {
+      expect(vm.isClient).toBe(false);
+    });
+
+    it('is true when currentUser has role client', async () => {
+      vi.mocked(authService.signIn).mockResolvedValue(makeUser({ role: 'client' }));
+      await vm.signIn('a@b.com', 'x');
+      expect(vm.isClient).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // clearError()
+  // ---------------------------------------------------------------------------
+
+  describe('clearError()', () => {
+    it('resets error to null', async () => {
+      vi.mocked(authService.signIn).mockRejectedValue(new Error('oops'));
+      await vm.signIn('a@b.com', 'x');
+
+      vm.clearError();
+      expect(vm.error).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **`IAuthService`** added to `src/core/repositories/index.ts` alongside the other `I*` interfaces; `AuthUser` and `UserRole` added to domain types — `supabase.ts` now imports `UserRole` from the domain instead of redefining it
- **`SupabaseAuthService`** — wraps Supabase Auth (signIn, signOut, getCurrentUser, onAuthStateChange) and enriches each session with the user's role fetched from `user_profiles`
- **`NoopAuthService`** — always-succeeds fallback when `NEXT_PUBLIC_SUPABASE_URL` is not set (localStorage dev mode)
- **`AuthViewModel`** (MobX) — observable `currentUser`, `isLoading`, `error`; computed `isAuthenticated`, `isTrainer`, `isClient`; actions `signIn`, `signOut`, `initialize`, `dispose`
- **`AuthProvider`** — selects the right service at runtime based on env vars, wraps the app via `layout.tsx`, exposes `useAuthViewModel()`
- **`src/lib/supabase.ts`** — lazy singleton browser client factory
- **`/login` page** — `observer` component with email/password form, error display, loading state, and role-based redirect after sign-in

## Test plan

- [ ] 24 new unit tests in `tests/unit/core/view-models/AuthViewModel.test.ts` — all states, actions, and computed values
- [ ] 280 tests pass total: `npx vitest run`
- [ ] `tsc --noEmit` clean
- [ ] Manual: visit `/login`, enter credentials → redirects to `/trainer` or `/client`
- [ ] Manual: in localStorage mode (no env vars) → NoopAuthService lets you sign in with any credentials

https://claude.ai/code/session_01QLt6xhMZPQZntXLtbSSszH

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLt6xhMZPQZntXLtbSSszH)_