### PR TITLE
feat: AuthGuard — protect /client and /trainer routes with role enforcement

### DIFF
--- a/src/app/client/layout.tsx
+++ b/src/app/client/layout.tsx
@@ -1,0 +1,6 @@
+import { ReactNode } from 'react';
+import { AuthGuard } from '@/components/AuthGuard';
+
+export default function ClientLayout({ children }: { children: ReactNode }) {
+  return <AuthGuard allowedRole="client">{children}</AuthGuard>;
+}

--- a/src/app/trainer/layout.tsx
+++ b/src/app/trainer/layout.tsx
@@ -1,0 +1,6 @@
+import { ReactNode } from 'react';
+import { AuthGuard } from '@/components/AuthGuard';
+
+export default function TrainerLayout({ children }: { children: ReactNode }) {
+  return <AuthGuard allowedRole="trainer">{children}</AuthGuard>;
+}

--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, ReactNode } from 'react';
+import { useRouter } from 'next/navigation';
+import { observer } from 'mobx-react-lite';
+import { useAuthViewModel } from '@/core/providers/AuthProvider';
+import { UserRole } from '@/core/types';
+
+interface AuthGuardProps {
+  children: ReactNode;
+  /** When provided, also enforces that the authenticated user has this role. */
+  allowedRole?: UserRole;
+}
+
+export const AuthGuard = observer(({ children, allowedRole }: AuthGuardProps) => {
+  const authVM = useAuthViewModel();
+  const router = useRouter();
+
+  const roleRedirect = authVM.isTrainer ? '/trainer' : '/client';
+
+  useEffect(() => {
+    if (authVM.isLoading) return;
+
+    if (!authVM.isAuthenticated) {
+      router.replace('/login');
+      return;
+    }
+
+    if (allowedRole && authVM.currentUser?.role !== allowedRole) {
+      router.replace(roleRedirect);
+    }
+  }, [authVM.isLoading, authVM.isAuthenticated, authVM.currentUser?.role, allowedRole, router, roleRedirect]);
+
+  if (authVM.isLoading) {
+    return (
+      <div data-testid="auth-guard-loading" className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="animate-pulse text-gray-400 text-sm">Cargando…</div>
+      </div>
+    );
+  }
+
+  if (!authVM.isAuthenticated) return null;
+  if (allowedRole && authVM.currentUser?.role !== allowedRole) return null;
+
+  return <>{children}</>;
+});

--- a/tests/unit/components/AuthGuard.test.tsx
+++ b/tests/unit/components/AuthGuard.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AuthGuard } from '@/components/AuthGuard';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockReplace = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+vi.mock('@/core/providers/AuthProvider', () => ({
+  useAuthViewModel: vi.fn(),
+}));
+
+import { useAuthViewModel } from '@/core/providers/AuthProvider';
+
+function mockAuth(state: {
+  isLoading?: boolean;
+  isAuthenticated?: boolean;
+  role?: 'client' | 'trainer' | null;
+}) {
+  vi.mocked(useAuthViewModel).mockReturnValue({
+    isLoading: state.isLoading ?? false,
+    isAuthenticated: state.isAuthenticated ?? false,
+    currentUser: state.role ? { id: 'u1', email: 'test@nivel.gym', role: state.role } : null,
+    isTrainer: state.role === 'trainer',
+    isClient: state.role === 'client',
+  } as ReturnType<typeof useAuthViewModel>);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AuthGuard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  describe('while auth is loading', () => {
+    it('renders a loading indicator', () => {
+      mockAuth({ isLoading: true });
+      render(<AuthGuard><p>protected</p></AuthGuard>);
+      expect(screen.getByTestId('auth-guard-loading')).toBeInTheDocument();
+    });
+
+    it('does not render children while loading', () => {
+      mockAuth({ isLoading: true });
+      render(<AuthGuard><p>protected</p></AuthGuard>);
+      expect(screen.queryByText('protected')).not.toBeInTheDocument();
+    });
+
+    it('does not redirect while loading', () => {
+      mockAuth({ isLoading: true });
+      render(<AuthGuard><p>protected</p></AuthGuard>);
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Unauthenticated
+  // -------------------------------------------------------------------------
+
+  describe('when user is not authenticated', () => {
+    it('redirects to /login', () => {
+      mockAuth({ isLoading: false, isAuthenticated: false });
+      render(<AuthGuard><p>protected</p></AuthGuard>);
+      expect(mockReplace).toHaveBeenCalledWith('/login');
+    });
+
+    it('does not render children', () => {
+      mockAuth({ isLoading: false, isAuthenticated: false });
+      render(<AuthGuard><p>protected</p></AuthGuard>);
+      expect(screen.queryByText('protected')).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Authenticated — no role restriction
+  // -------------------------------------------------------------------------
+
+  describe('when user is authenticated and no allowedRole is specified', () => {
+    it('renders children', () => {
+      mockAuth({ isLoading: false, isAuthenticated: true, role: 'client' });
+      render(<AuthGuard><p>protected</p></AuthGuard>);
+      expect(screen.getByText('protected')).toBeInTheDocument();
+    });
+
+    it('does not redirect', () => {
+      mockAuth({ isLoading: false, isAuthenticated: true, role: 'trainer' });
+      render(<AuthGuard><p>protected</p></AuthGuard>);
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Authenticated — role matches
+  // -------------------------------------------------------------------------
+
+  describe('when role matches allowedRole', () => {
+    it('renders children for a client accessing client route', () => {
+      mockAuth({ isLoading: false, isAuthenticated: true, role: 'client' });
+      render(<AuthGuard allowedRole="client"><p>client area</p></AuthGuard>);
+      expect(screen.getByText('client area')).toBeInTheDocument();
+    });
+
+    it('renders children for a trainer accessing trainer route', () => {
+      mockAuth({ isLoading: false, isAuthenticated: true, role: 'trainer' });
+      render(<AuthGuard allowedRole="trainer"><p>trainer area</p></AuthGuard>);
+      expect(screen.getByText('trainer area')).toBeInTheDocument();
+    });
+
+    it('does not redirect when role matches', () => {
+      mockAuth({ isLoading: false, isAuthenticated: true, role: 'client' });
+      render(<AuthGuard allowedRole="client"><p>client area</p></AuthGuard>);
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Authenticated — role mismatch
+  // -------------------------------------------------------------------------
+
+  describe('when role does not match allowedRole', () => {
+    it('redirects a trainer who visits /client to /trainer', () => {
+      mockAuth({ isLoading: false, isAuthenticated: true, role: 'trainer' });
+      render(<AuthGuard allowedRole="client"><p>client area</p></AuthGuard>);
+      expect(mockReplace).toHaveBeenCalledWith('/trainer');
+    });
+
+    it('redirects a client who visits /trainer to /client', () => {
+      mockAuth({ isLoading: false, isAuthenticated: true, role: 'client' });
+      render(<AuthGuard allowedRole="trainer"><p>trainer area</p></AuthGuard>);
+      expect(mockReplace).toHaveBeenCalledWith('/client');
+    });
+
+    it('does not render children when role mismatches', () => {
+      mockAuth({ isLoading: false, isAuthenticated: true, role: 'trainer' });
+      render(<AuthGuard allowedRole="client"><p>client area</p></AuthGuard>);
+      expect(screen.queryByText('client area')).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **`AuthGuard`** (`src/components/AuthGuard.tsx`) — `observer` component (presentation layer) that reads `AuthViewModel` and enforces two rules:
  1. Unauthenticated → redirect to `/login`
  2. Wrong role → redirect to the correct dashboard (`/trainer` or `/client`)
- **`app/client/layout.tsx`** — wraps the client route with `<AuthGuard allowedRole="client">`
- **`app/trainer/layout.tsx`** — wraps the trainer route with `<AuthGuard allowedRole="trainer">`

**Behaviour matrix:**

| State | Result |
|-------|--------|
| `isLoading=true` | Show loading screen (`data-testid="auth-guard-loading"`), no redirect |
| `isAuthenticated=false` | Redirect → `/login` |
| Authenticated, role matches | Render children |
| Authenticated, role mismatches | Redirect → correct dashboard |

## Patterns followed
- Presentation layer only — `AuthGuard` reads `AuthViewModel`, never touches `AuthModel` or `IAuthService` directly
- `data-testid` added for E2E coverage
- TDD: 13 tests written before implementation

## Test plan
- [ ] 13 unit tests in `tests/unit/components/AuthGuard.test.tsx`
- [ ] 330 tests passing: `npx vitest run`
- [ ] `tsc --noEmit` clean
- [ ] Manual: unauthenticated visit to `/client` → redirects to `/login`
- [ ] Manual: trainer visiting `/client` → redirects to `/trainer`

https://claude.ai/code/session_01QLt6xhMZPQZntXLtbSSszH

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLt6xhMZPQZntXLtbSSszH)_