### PR TITLE
refactor: move booking ID generation to Repository layer (IBookingRepository.create)

### DIFF
--- a/src/core/models/BookingModel.ts
+++ b/src/core/models/BookingModel.ts
@@ -16,14 +16,7 @@ export class BookingModel {
     // Validar capacidad en tiempo real
     await this.validateCapacity(booking);
     
-    const newBooking: Booking = {
-      ...booking,
-      id: `booking_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
-    };
-    
-    await this.dataService.bookings.save(newBooking);
-
-    return newBooking;
+    return this.dataService.bookings.create(booking);
   }
 
   async getTrainers(): Promise<Trainer[]> {

--- a/src/core/repositories/index.ts
+++ b/src/core/repositories/index.ts
@@ -22,6 +22,7 @@ export interface IBookingRepository {
   getById(id: string): Promise<Booking | null>;
   getByDate(date: Date): Promise<Booking[]>;
   getByTrainer(trainerId: string): Promise<Booking[]>;
+  create(booking: Omit<Booking, 'id'>): Promise<Booking>;
   save(booking: Booking): Promise<void>;
   update(id: string, booking: Partial<Booking>): Promise<void>;
   delete(id: string): Promise<void>;

--- a/src/core/repositories/localStorage.ts
+++ b/src/core/repositories/localStorage.ts
@@ -301,16 +301,22 @@ class LocalStorageBookingRepository implements IBookingRepository {
     return bookings.filter(b => b.trainerId === trainerId);
   }
 
+  async create(booking: Omit<Booking, 'id'>): Promise<Booking> {
+    const newBooking: Booking = { ...booking, id: crypto.randomUUID() };
+    await this.save(newBooking);
+    return newBooking;
+  }
+
   async save(booking: Booking): Promise<void> {
     const bookings = await this.getAll();
     const index = bookings.findIndex(b => b.id === booking.id);
-    
+
     if (index >= 0) {
       bookings[index] = booking;
     } else {
       bookings.push(booking);
     }
-    
+
     localStorage.setItem(this.key, JSON.stringify(bookings));
   }
 

--- a/src/core/services/SupabaseDataService.ts
+++ b/src/core/services/SupabaseDataService.ts
@@ -196,6 +196,16 @@ export class SupabaseBookingRepository implements IBookingRepository {
     return (data as BookingRow[]).map(BookingMapper.toDomain);
   }
 
+  async create(booking: Omit<Booking, 'id'>): Promise<Booking> {
+    const { data, error } = await this.client
+      .from('bookings')
+      .insert(BookingMapper.toInsert(booking))
+      .select()
+      .single();
+    if (error) throw new Error(error.message);
+    return BookingMapper.toDomain(data as BookingRow);
+  }
+
   async save(booking: Booking): Promise<void> {
     const { id, ...rest } = booking;
     const row = { id, ...BookingMapper.toInsert(rest) };

--- a/tests/unit/core/models/BookingModel.test.ts
+++ b/tests/unit/core/models/BookingModel.test.ts
@@ -18,6 +18,7 @@ const mockBookingRepository = {
   getById: vi.fn(),
   getByDate: vi.fn(),
   getByTrainer: vi.fn(),
+  create: vi.fn(),
   save: vi.fn(),
   update: vi.fn(),
   delete: vi.fn()
@@ -74,24 +75,26 @@ describe('BookingModel', () => {
     }
 
     it('should create a booking successfully', async () => {
+      const createdBooking = { ...validBookingData, id: 'generated-uuid' }
       mockTrainerRepository.getById.mockResolvedValue(mockTrainer)
       mockTrainerRepository.getSchedule.mockResolvedValue(null)
       mockBookingRepository.getByDate.mockResolvedValue([])
-      mockBookingRepository.save.mockResolvedValue(undefined)
+      mockBookingRepository.create.mockResolvedValue(createdBooking)
 
       const result = await bookingModel.createBooking(validBookingData)
 
-      expect(result).toMatchObject(validBookingData)
+      expect(result).toEqual(createdBooking)
       expect(result.id).toBeDefined()
-      expect(result.id).toMatch(/^booking_\d+_[a-z0-9]+$/)
-      expect(mockBookingRepository.save).toHaveBeenCalledWith(result)
+      expect(mockBookingRepository.create).toHaveBeenCalledWith(validBookingData)
+      expect(mockBookingRepository.save).not.toHaveBeenCalled()
     })
 
     it('should not touch the program repository when creating a booking', async () => {
+      const createdBooking = { ...validBookingData, id: 'generated-uuid' }
       mockTrainerRepository.getById.mockResolvedValue(mockTrainer)
       mockTrainerRepository.getSchedule.mockResolvedValue(null)
       mockBookingRepository.getByDate.mockResolvedValue([])
-      mockBookingRepository.save.mockResolvedValue(undefined)
+      mockBookingRepository.create.mockResolvedValue(createdBooking)
 
       await bookingModel.createBooking(validBookingData)
 
@@ -195,9 +198,11 @@ describe('BookingModel', () => {
     })
 
     it('should not throw BookingCapacityError when only a different zone is full', async () => {
+      const gabineteBooking = { ...validBookingData, zone: 'gabinete' as ZoneType }
+      const createdBooking = { ...gabineteBooking, id: 'generated-uuid' }
       mockTrainerRepository.getById.mockResolvedValue(mockTrainer)
       mockTrainerRepository.getSchedule.mockResolvedValue(null)
-      mockBookingRepository.save.mockResolvedValue(undefined)
+      mockBookingRepository.create.mockResolvedValue(createdBooking)
 
       // Fill gym zone (maxCapacity = 10) but leave gabinete empty
       const gymBookings: Booking[] = Array.from({ length: 10 }, (_, i): Booking => ({
@@ -218,7 +223,6 @@ describe('BookingModel', () => {
       mockBookingRepository.getByDate.mockResolvedValue(gymBookings)
 
       // Booking gabinete should succeed — gym is full but gabinete is not
-      const gabineteBooking = { ...validBookingData, zone: 'gabinete' as ZoneType }
       const result = await bookingModel.createBooking(gabineteBooking)
 
       expect(result).toMatchObject(gabineteBooking)

--- a/tests/unit/core/models/ProgramModel.test.ts
+++ b/tests/unit/core/models/ProgramModel.test.ts
@@ -40,6 +40,7 @@ const mockDataService: IDataService = {
     getById: vi.fn(),
     getByDate: vi.fn(),
     getByTrainer: vi.fn(),
+    create: vi.fn(),
     save: vi.fn(),
     update: vi.fn(),
     delete: vi.fn()

--- a/tests/unit/core/models/TrainerModel.test.ts
+++ b/tests/unit/core/models/TrainerModel.test.ts
@@ -17,6 +17,7 @@ const mockBookingRepository = {
   getById: vi.fn(),
   getByDate: vi.fn(),
   getByTrainer: vi.fn(),
+  create: vi.fn(),
   save: vi.fn(),
   update: vi.fn(),
   delete: vi.fn()

--- a/tests/unit/core/services/SupabaseDataService.test.ts
+++ b/tests/unit/core/services/SupabaseDataService.test.ts
@@ -23,6 +23,7 @@ function makeBuilder(result: { data: unknown; error: { message: string } | null 
   const builder: Record<string, unknown> = {
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
     single: vi.fn().mockResolvedValue(result),
     upsert: vi.fn().mockResolvedValue({ data: null, error: null }),
     update: vi.fn().mockReturnThis(),
@@ -172,6 +173,56 @@ describe('SupabaseBookingRepository', () => {
       await repo.getByTrainer('t1');
 
       expect(builder.eq).toHaveBeenCalledWith('trainer_id', 't1');
+    });
+  });
+
+  describe('create', () => {
+    it('inserts without id, selects the created row, and returns a mapped Booking', async () => {
+      const builder = makeBuilder({ data: bookingRow, error: null });
+      const client = makeClient(builder);
+      const repo = new SupabaseBookingRepository(client);
+
+      const result = await repo.create({
+        clientId: 'c1',
+        trainerId: 't1',
+        trainerName: 'Diego Lamas',
+        date: new Date('2026-05-11'),
+        time: '09:00',
+        duration: 60,
+        zone: 'gym',
+        status: 'confirmed',
+      });
+
+      expect(client.from).toHaveBeenCalledWith('bookings');
+      expect(builder.insert).toHaveBeenCalledWith(
+        expect.objectContaining({ client_id: 'c1', time_slot: '09:00' }),
+      );
+      expect(builder.insert).toHaveBeenCalledWith(
+        expect.not.objectContaining({ id: expect.anything() }),
+      );
+      expect(builder.select).toHaveBeenCalled();
+      expect(builder.single).toHaveBeenCalled();
+      expect(result.id).toBe('b1');
+      expect(result.clientId).toBe('c1');
+    });
+
+    it('throws when Supabase returns an error', async () => {
+      const builder = makeBuilder({ data: null, error: { message: 'insert failed' } });
+      const client = makeClient(builder);
+      const repo = new SupabaseBookingRepository(client);
+
+      await expect(
+        repo.create({
+          clientId: 'c1',
+          trainerId: 't1',
+          trainerName: 'Diego',
+          date: new Date('2026-05-11'),
+          time: '09:00',
+          duration: 60,
+          zone: 'gym',
+          status: 'confirmed',
+        }),
+      ).rejects.toThrow('insert failed');
     });
   });
 


### PR DESCRIPTION
Closes #110

## Resumen

- Agrega `create(booking: Omit<Booking, 'id'>): Promise<Booking>` a `IBookingRepository`
- `LocalStorageBookingRepository.create()` asigna ID vía `crypto.randomUUID()`
- `SupabaseBookingRepository.create()` hace INSERT sin `id` y Supabase asigna el UUID server-side
- `BookingModel.createBooking()` delega completamente a `dataService.bookings.create()` sin generar ID

Generated with [Claude Code](https://claude.ai/code)