### PR TITLE
feat: ClientModel + ClientViewModel — elimina useData() de componentes (#95)

### DIFF
--- a/src/components/trainer/CreateProgramForm.tsx
+++ b/src/components/trainer/CreateProgramForm.tsx
@@ -3,8 +3,7 @@
 import { useEffect } from 'react';
 import { observer } from 'mobx-react-lite';
 import { format } from 'date-fns';
-import { useProgramViewModel } from '@/core/providers/ViewModelProvider';
-import { useData } from '@/core/providers/DataProvider';
+import { useProgramViewModel, useClientViewModel } from '@/core/providers/ViewModelProvider';
 
 const TRAINER_ID = 'trainer1';
 
@@ -37,7 +36,7 @@ function computeWeeklyFrequency(
 
 const CreateProgramForm = observer(function CreateProgramForm() {
   const programVM = useProgramViewModel();
-  const { clients } = useData();
+  const clientVM = useClientViewModel();
 
   useEffect(() => {
     programVM.setFormTrainerId(TRAINER_ID);
@@ -189,8 +188,8 @@ const CreateProgramForm = observer(function CreateProgramForm() {
         <label className="block text-sm font-medium text-gray-700 mb-2">
           Cliente(s) <span className="text-red-500">*</span>
         </label>
-        <div data-testid="clients-checkbox-container" className="grid grid-cols-2 sm:grid-cols-3 gap-2 max-h-48 overflow-y-auto border border-gray-200 rounded-lg p-3">
-          {clients.filter(c => c.status === 'active').map(client => (
+        <div data-testid="clientVM.clients-checkbox-container" className="grid grid-cols-2 sm:grid-cols-3 gap-2 max-h-48 overflow-y-auto border border-gray-200 rounded-lg p-3">
+          {clientVM.clients.filter(c => c.status === 'active').map(client => (
             <label
               key={client.id}
               className="flex items-center space-x-2 cursor-pointer"
@@ -205,7 +204,7 @@ const CreateProgramForm = observer(function CreateProgramForm() {
               <span className="text-sm text-gray-700 truncate">{client.name}</span>
             </label>
           ))}
-          {clients.filter(c => c.status === 'active').length === 0 && (
+          {clientVM.clients.filter(c => c.status === 'active').length === 0 && (
             <p className="text-sm text-gray-400 col-span-full">No hay clientes activos</p>
           )}
         </div>

--- a/src/components/trainer/ProgramListView.tsx
+++ b/src/components/trainer/ProgramListView.tsx
@@ -4,8 +4,7 @@ import { useEffect, useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
-import { useProgramViewModel } from '@/core/providers/ViewModelProvider';
-import { useData } from '@/core/providers/DataProvider';
+import { useProgramViewModel, useClientViewModel } from '@/core/providers/ViewModelProvider';
 import { Program } from '@/core/types';
 import RenewProgramModal from './RenewProgramModal';
 
@@ -48,17 +47,14 @@ function StatusBadge({ status }: { status: Program['status'] }) {
 
 const ProgramListView = observer(function ProgramListView() {
   const programVM = useProgramViewModel();
-  const { clients } = useData();
+  const clientVM = useClientViewModel();
   const [renewTarget, setRenewTarget] = useState<Program | null>(null);
 
   useEffect(() => {
     programVM.loadPrograms(TRAINER_ID);
   }, [programVM]);
 
-  const getClientNames = (clientIds: string[]) =>
-    clientIds
-      .map(id => clients.find(c => c.id === id)?.name ?? id)
-      .join(', ');
+  const getClientNames = (clientIds: string[]) => clientVM.getClientNames(clientIds);
 
   const handleRenewSuccess = async () => {
     setRenewTarget(null);

--- a/src/components/trainer/RenewProgramModal.tsx
+++ b/src/components/trainer/RenewProgramModal.tsx
@@ -2,8 +2,7 @@
 
 import { useState } from 'react';
 import { observer } from 'mobx-react-lite';
-import { useProgramViewModel } from '@/core/providers/ViewModelProvider';
-import { useData } from '@/core/providers/DataProvider';
+import { useProgramViewModel, useClientViewModel } from '@/core/providers/ViewModelProvider';
 import { Program } from '@/core/types';
 
 interface RenewProgramModalProps {
@@ -18,12 +17,10 @@ const RenewProgramModal = observer(function RenewProgramModal({
   onSuccess
 }: RenewProgramModalProps) {
   const programVM = useProgramViewModel();
-  const { clients } = useData();
+  const clientVM = useClientViewModel();
   const [newSessions, setNewSessions] = useState(program.totalSessions);
 
-  const clientNames = program.clientIds
-    .map(id => clients.find(c => c.id === id)?.name ?? id)
-    .join(', ');
+  const clientNames = clientVM.getClientNames(program.clientIds);
 
   const handleRenew = async () => {
     const success = await programVM.renewProgram(program.id, newSessions);

--- a/src/components/trainer/TrainerAppointments.tsx
+++ b/src/components/trainer/TrainerAppointments.tsx
@@ -3,15 +3,14 @@
 import { useEffect, useState } from 'react';
 import { format, startOfWeek, addDays, isSameDay, addWeeks, subWeeks } from 'date-fns';
 import { es } from 'date-fns/locale';
-import { useData } from '@/core/providers/DataProvider';
-import { useTrainerViewModel } from '@/core/providers/ViewModelProvider';
+import { useTrainerViewModel, useClientViewModel } from '@/core/providers/ViewModelProvider';
 import { Booking, ZONE_CONFIG } from '@/core/types';
 import { TimeSlotWithCapacity } from '@/core/types';
 
 
 export default function TrainerAppointments() {
   const vm = useTrainerViewModel();
-  const { clients } = useData();
+  const clientVM = useClientViewModel();
   const { bookings, isLoading } = vm;
 
   useEffect(() => {
@@ -20,8 +19,7 @@ export default function TrainerAppointments() {
 
   const [currentWeek, setCurrentWeek] = useState(new Date());
 
-  const getClientName = (clientId: string) =>
-    clients.find(c => c.id === clientId)?.name ?? clientId;
+  const getClientName = (clientId: string) => clientVM.getClientName(clientId);
 
   const weekStart = startOfWeek(currentWeek, { weekStartsOn: 1 }); // Start on Monday
   const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));

--- a/src/core/models/ClientModel.ts
+++ b/src/core/models/ClientModel.ts
@@ -1,0 +1,22 @@
+import { Client } from '../types';
+import { ClientNotFoundError } from '../types/errors';
+import { IDataService } from '../repositories';
+
+export class ClientModel {
+  constructor(private dataService: IDataService) {}
+
+  async getAll(): Promise<Client[]> {
+    return this.dataService.clients.getAll();
+  }
+
+  async getById(id: string): Promise<Client> {
+    const client = await this.dataService.clients.getById(id);
+    if (!client) throw new ClientNotFoundError(id);
+    return client;
+  }
+
+  async validateClientExists(id: string): Promise<void> {
+    const client = await this.dataService.clients.getById(id);
+    if (!client) throw new ClientNotFoundError(id);
+  }
+}

--- a/src/core/providers/ViewModelProvider.tsx
+++ b/src/core/providers/ViewModelProvider.tsx
@@ -1,18 +1,21 @@
 'use client';
 
-import React, { createContext, useContext, useMemo, ReactNode } from 'react';
+import React, { createContext, useContext, useEffect, useMemo, ReactNode } from 'react';
 import { BookingViewModel } from '../view-models/BookingViewModel';
 import { BookingModel } from '../models/BookingModel';
 import { ProgramViewModel } from '../view-models/ProgramViewModel';
 import { ProgramModel } from '../models/ProgramModel';
 import { TrainerViewModel } from '../view-models/TrainerViewModel';
 import { TrainerModel } from '../models/TrainerModel';
+import { ClientViewModel } from '../view-models/ClientViewModel';
+import { ClientModel } from '../models/ClientModel';
 import { useDataService } from './DataProvider';
 
 interface ViewModelContextType {
   bookingVM: BookingViewModel;
   programVM: ProgramViewModel;
   trainerVM: TrainerViewModel;
+  clientVM: ClientViewModel;
 }
 
 const ViewModelContext = createContext<ViewModelContextType | null>(null);
@@ -28,17 +31,19 @@ export function ViewModelProvider({ children }: ViewModelProviderProps) {
     const bookingModel = new BookingModel(service);
     const programModel = new ProgramModel(service);
     const trainerModel = new TrainerModel(service);
+    const clientModel = new ClientModel(service);
 
     const bookingVM = new BookingViewModel(bookingModel, programModel);
     const programVM = new ProgramViewModel(programModel);
     const trainerVM = new TrainerViewModel(bookingModel, trainerModel);
+    const clientVM = new ClientViewModel(clientModel);
 
-    return {
-      bookingVM,
-      programVM,
-      trainerVM
-    };
+    return { bookingVM, programVM, trainerVM, clientVM };
   }, [service]);
+
+  useEffect(() => {
+    viewModels.clientVM.loadClients();
+  }, [viewModels]);
 
   return (
     <ViewModelContext.Provider value={viewModels}>
@@ -68,4 +73,9 @@ export function useProgramViewModel() {
 export function useTrainerViewModel() {
   const { trainerVM } = useViewModels();
   return trainerVM;
+}
+
+export function useClientViewModel() {
+  const { clientVM } = useViewModels();
+  return clientVM;
 }

--- a/src/core/types/errors.ts
+++ b/src/core/types/errors.ts
@@ -75,3 +75,10 @@ export class TrainerValidationError extends Error {
     this.name = 'TrainerValidationError';
   }
 }
+
+export class ClientNotFoundError extends Error {
+  constructor(public clientId: string) {
+    super(`Cliente no encontrado: ${clientId}`);
+    this.name = 'ClientNotFoundError';
+  }
+}

--- a/src/core/view-models/ClientViewModel.ts
+++ b/src/core/view-models/ClientViewModel.ts
@@ -1,0 +1,40 @@
+import { makeAutoObservable, runInAction } from 'mobx';
+import { Client } from '../types';
+import { ClientModel } from '../models/ClientModel';
+
+export class ClientViewModel {
+  clients: Client[] = [];
+  isLoading = false;
+  error: string | null = null;
+
+  constructor(private model: ClientModel) {
+    makeAutoObservable(this);
+  }
+
+  async loadClients(): Promise<void> {
+    this.isLoading = true;
+    try {
+      const clients = await this.model.getAll();
+      runInAction(() => {
+        this.clients = clients;
+        this.error = null;
+      });
+    } catch (err) {
+      runInAction(() => {
+        this.error = err instanceof Error ? err.message : 'Error cargando clientes';
+      });
+    } finally {
+      runInAction(() => {
+        this.isLoading = false;
+      });
+    }
+  }
+
+  getClientName(id: string): string {
+    return this.clients.find(c => c.id === id)?.name ?? id;
+  }
+
+  getClientNames(ids: string[]): string {
+    return ids.map(id => this.getClientName(id)).join(', ');
+  }
+}

--- a/tests/unit/core/models/ClientModel.test.ts
+++ b/tests/unit/core/models/ClientModel.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ClientModel } from '@/core/models/ClientModel';
+import { ClientNotFoundError } from '@/core/types/errors';
+import { Client } from '@/core/types';
+
+const client1: Client = {
+  id: 'client1',
+  name: 'María González',
+  email: 'maria@email.com',
+  phone: '+34 611 000 001',
+  status: 'active',
+  createdAt: new Date(2025, 0, 1),
+};
+
+const mockDataService = {
+  clients: {
+    getAll: vi.fn(),
+    getById: vi.fn(),
+    getByEmail: vi.fn(),
+    save: vi.fn(),
+    delete: vi.fn(),
+  },
+  trainers: {} as never,
+  bookings: {} as never,
+  programs: {} as never,
+  initialize: vi.fn(),
+  clear: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ClientModel.getAll()', () => {
+  it('devuelve todos los clientes del repositorio', async () => {
+    mockDataService.clients.getAll.mockResolvedValue([client1]);
+    const model = new ClientModel(mockDataService as never);
+
+    const result = await model.getAll();
+
+    expect(result).toEqual([client1]);
+  });
+});
+
+describe('ClientModel.getById()', () => {
+  it('devuelve el cliente cuando existe', async () => {
+    mockDataService.clients.getById.mockResolvedValue(client1);
+    const model = new ClientModel(mockDataService as never);
+
+    const result = await model.getById('client1');
+
+    expect(result).toEqual(client1);
+  });
+
+  it('lanza ClientNotFoundError cuando el cliente no existe', async () => {
+    mockDataService.clients.getById.mockResolvedValue(null);
+    const model = new ClientModel(mockDataService as never);
+
+    await expect(model.getById('unknown')).rejects.toThrow(ClientNotFoundError);
+    await expect(model.getById('unknown')).rejects.toThrow('unknown');
+  });
+});
+
+describe('ClientModel.validateClientExists()', () => {
+  it('resuelve sin error cuando el cliente existe', async () => {
+    mockDataService.clients.getById.mockResolvedValue(client1);
+    const model = new ClientModel(mockDataService as never);
+
+    await expect(model.validateClientExists('client1')).resolves.toBeUndefined();
+  });
+
+  it('lanza ClientNotFoundError cuando el cliente no existe', async () => {
+    mockDataService.clients.getById.mockResolvedValue(null);
+    const model = new ClientModel(mockDataService as never);
+
+    await expect(model.validateClientExists('ghost')).rejects.toThrow(ClientNotFoundError);
+  });
+});


### PR DESCRIPTION
Closes #95

## Summary

- **`ClientNotFoundError`** en `src/core/types/errors.ts`
- **`ClientModel`** en `src/core/models/ClientModel.ts` — `getAll()`, `getById()` (lanza `ClientNotFoundError`), `validateClientExists()`
- **`ClientViewModel`** en `src/core/view-models/ClientViewModel.ts` — `clients: Client[]` observable MobX, `loadClients()`, helpers `getClientName()` y `getClientNames()`
- **`ViewModelProvider`** — instancia `ClientModel` + `ClientViewModel`; llama `clientVM.loadClients()` via `useEffect` al montar; expone `useClientViewModel()`
- **Migración de 4 componentes** a `useClientViewModel()`:
  - `CreateProgramForm` — usa `clientVM.clients` para el selector de clientes
  - `ProgramListView` — usa `clientVM.getClientNames()` para mostrar nombres
  - `RenewProgramModal` — usa `clientVM.getClientNames()` para mostrar nombres
  - `TrainerAppointments` — usa `clientVM.getClientName()` para resolver nombres en el detalle de citas

**Resultado:** ningún componente importa `useData()` — el flujo MVVM está completo en todas las capas.

## Test plan

- [ ] Los programas del entrenador muestran los nombres de los clientes correctamente
- [ ] El formulario de crear programa lista los clientes activos para seleccionar
- [ ] El modal de renovar programa muestra el nombre del cliente
- [ ] La vista de citas del entrenador muestra el nombre del cliente en el detalle
- [ ] Tests unitarios de `ClientModel` pasan en CI

https://claude.ai/code/session_01K8VxzUriMSjACtkdfpLRVF

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8VxzUriMSjACtkdfpLRVF)_