### PR TITLE
refactor(#68): remove activeProgram duplicate from BookingViewModel

### DIFF
--- a/src/components/BookingView.tsx
+++ b/src/components/BookingView.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect } from 'react';
 import { observer } from 'mobx-react-lite';
-import { useBookingViewModel } from '@/core/providers/ViewModelProvider';
+import { useBookingViewModel, useProgramViewModel } from '@/core/providers/ViewModelProvider';
 import CalendarStep from './CalendarStep';
 import SuccessModal from './SuccessModal';
 import { format, isSameDay } from 'date-fns';
@@ -11,13 +11,14 @@ import { Booking, ZoneType, ZONE_CONFIG } from '@/core/types';
 
 // Muestra las sesiones pendientes del programa activo en la sección de confirmación
 const ProgramSessionInfo = observer(() => {
-  const vm = useBookingViewModel();
+  const programVM = useProgramViewModel();
 
-  if (!vm.hasActiveProgram || vm.pendingSessions === null) {
+  if (!programVM.hasActiveProgram || programVM.activeProgramPendingSessions === null) {
     return null;
   }
 
-  const pendingAfterBooking = vm.pendingSessions - 1;
+  const pendingSessions = programVM.activeProgramPendingSessions;
+  const pendingAfterBooking = pendingSessions - 1;
   const isLow = pendingAfterBooking >= 0 && pendingAfterBooking < 3;
 
   return (
@@ -30,7 +31,7 @@ const ProgramSessionInfo = observer(() => {
         </svg>
         <p className={isLow ? 'text-orange-800' : 'text-indigo-800'}>
           <span className="font-semibold">Mi Programa:</span>{' '}
-          {vm.pendingSessions === 0
+          {pendingSessions === 0
             ? 'No tienes sesiones pendientes. Habla con tu entrenador para renovar.'
             : pendingAfterBooking <= 0
             ? 'Esta será tu última sesión del programa.'
@@ -49,11 +50,13 @@ const ProgramSessionInfo = observer(() => {
 
 const BookingView = observer(() => {
   const vm = useBookingViewModel();
+  const programVM = useProgramViewModel();
 
   // Inicializar ViewModel después de la hidratación
   useEffect(() => {
     vm.initialize();
-  }, [vm]);
+    programVM.loadActiveProgram(vm.clientId);
+  }, [vm, programVM]);
 
   const handleDateSelect = (date: Date) => {
     vm.setDate(date);
@@ -76,6 +79,7 @@ const BookingView = observer(() => {
     const success = await vm.createBooking();
     if (success) {
       await vm.refreshBookings();
+      await programVM.loadActiveProgram(vm.clientId);
     }
   };
 

--- a/src/core/view-models/BookingViewModel.ts
+++ b/src/core/view-models/BookingViewModel.ts
@@ -1,7 +1,7 @@
 import { makeAutoObservable, runInAction } from 'mobx';
 import { BookingModel } from '../models/BookingModel';
 import { ProgramModel } from '../models/ProgramModel';
-import { Booking, Program, Trainer, ZoneType, ZONE_CONFIG } from '../types';
+import { Booking, Trainer, ZoneType, ZONE_CONFIG } from '../types';
 import { BookingCapacityError } from '../types/errors';
 
 interface ZoneCapacity {
@@ -20,7 +20,6 @@ export class BookingViewModel {
   trainers: Trainer[] = [];
   availableSlots: string[] = [];
   bookings: Booking[] = [];
-  activeProgram: Program | null = null;
   isLoading = false;
   error: string | null = null;
   
@@ -47,7 +46,6 @@ export class BookingViewModel {
     if (this.trainers.length === 0) {
       this.loadTrainers();
     }
-    this.loadActiveProgram(this.clientId);
   }
 
   // Acciones
@@ -65,17 +63,6 @@ export class BookingViewModel {
       });
     } finally {
       this.setLoading(false);
-    }
-  }
-
-  async loadActiveProgram(clientId: string): Promise<void> {
-    try {
-      const program = await this.programModel.getActiveProgram(clientId);
-      runInAction(() => {
-        this.activeProgram = program;
-      });
-    } catch {
-      // El programa es opcional — ignorar errores silenciosamente
     }
   }
 
@@ -122,11 +109,8 @@ export class BookingViewModel {
 
       const createdBooking = await this.model.createBooking(bookingData);
 
-      // Coordinar con ProgramModel: delegar el consumo de sesión completamente al Model
+      // Delegar consumo de sesión al ProgramModel — ProgramViewModel se recarga en la UI
       await this.programModel.consumeSessionForClient(this.clientId);
-
-      // Recargar el programa activo para reflejar la sesión descontada
-      await this.loadActiveProgram(this.clientId);
 
       runInAction(() => {
         this.error = null;
@@ -313,24 +297,5 @@ export class BookingViewModel {
 
   get hasAvailableSlots() {
     return this.availableSlots.length > 0;
-  }
-
-  get hasActiveProgram(): boolean {
-    return this.activeProgram !== null && this.activeProgram.status === 'active';
-  }
-
-  get pendingSessions(): number | null {
-    if (!this.activeProgram) return null;
-    return this.activeProgram.totalSessions - this.activeProgram.usedSessions;
-  }
-
-  get activeProgramProgress(): number | null {
-    if (!this.activeProgram) return null;
-    return (this.activeProgram.usedSessions / this.activeProgram.totalSessions) * 100;
-  }
-
-  get hasLowSessions(): boolean {
-    const pending = this.pendingSessions;
-    return pending !== null && pending > 0 && pending < 3;
   }
 }

--- a/tests/unit/core/view-models/BookingViewModel.test.ts
+++ b/tests/unit/core/view-models/BookingViewModel.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { BookingViewModel } from '@/core/view-models/BookingViewModel';
 import { BookingModel } from '@/core/models/BookingModel';
 import { ProgramModel } from '@/core/models/ProgramModel';
-import { Booking, Program, Trainer, ZoneType } from '@/core/types';
+import { Booking, Trainer, ZoneType } from '@/core/types';
 
 // Mock de BookingModel
 const mockBookingModel = {
@@ -17,31 +17,8 @@ const mockBookingModel = {
 
 // Mock de ProgramModel
 const mockProgramModel = {
-  createProgram: vi.fn(),
-  getActiveProgram: vi.fn(),
-  renewProgram: vi.fn(),
-  expireProgram: vi.fn(),
-  updateUsedSessions: vi.fn(),
-  consumeSession: vi.fn(),
-  consumeSessionForClient: vi.fn(),
-  getProgramsByTrainer: vi.fn(),
-  getProgramsByClient: vi.fn(),
-  getPendingSessions: vi.fn()
+  consumeSessionForClient: vi.fn()
 };
-
-const makeActiveProgram = (overrides: Partial<Program> = {}): Program => ({
-  id: 'program1',
-  name: 'Programa Fuerza',
-  description: 'Programa de fuerza',
-  trainerId: 'trainer1',
-  clientIds: ['client1'],
-  startDate: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
-  endDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
-  totalSessions: 20,
-  usedSessions: 5,
-  status: 'active',
-  ...overrides
-});
 
 const mockTrainer: Trainer = {
   id: 'trainer1',
@@ -60,122 +37,6 @@ describe('BookingViewModel', () => {
     vi.clearAllMocks();
   });
 
-  describe('loadActiveProgram', () => {
-    it('sets activeProgram when client has an active program', async () => {
-      const program = makeActiveProgram();
-      mockProgramModel.getActiveProgram.mockResolvedValue(program);
-
-      await vm.loadActiveProgram('client1');
-
-      expect(vm.activeProgram).toEqual(program);
-      expect(mockProgramModel.getActiveProgram).toHaveBeenCalledWith('client1');
-    });
-
-    it('sets activeProgram to null when client has no active program', async () => {
-      mockProgramModel.getActiveProgram.mockResolvedValue(null);
-
-      await vm.loadActiveProgram('client1');
-
-      expect(vm.activeProgram).toBeNull();
-    });
-
-    it('silently handles errors without setting vm.error', async () => {
-      mockProgramModel.getActiveProgram.mockRejectedValue(new Error('Network error'));
-
-      await vm.loadActiveProgram('client1');
-
-      expect(vm.error).toBeNull();
-      expect(vm.activeProgram).toBeNull();
-    });
-  });
-
-  describe('pendingSessions (computed)', () => {
-    it('returns null when there is no active program', () => {
-      expect(vm.pendingSessions).toBeNull();
-    });
-
-    it('returns correct pending sessions count', async () => {
-      mockProgramModel.getActiveProgram.mockResolvedValue(makeActiveProgram({ usedSessions: 5, totalSessions: 20 }));
-      await vm.loadActiveProgram('client1');
-
-      expect(vm.pendingSessions).toBe(15);
-    });
-
-    it('returns 0 when all sessions are used', async () => {
-      mockProgramModel.getActiveProgram.mockResolvedValue(makeActiveProgram({ usedSessions: 20, totalSessions: 20 }));
-      await vm.loadActiveProgram('client1');
-
-      expect(vm.pendingSessions).toBe(0);
-    });
-  });
-
-  describe('activeProgramProgress (computed)', () => {
-    it('returns null when there is no active program', () => {
-      expect(vm.activeProgramProgress).toBeNull();
-    });
-
-    it('returns correct progress percentage', async () => {
-      mockProgramModel.getActiveProgram.mockResolvedValue(makeActiveProgram({ usedSessions: 10, totalSessions: 20 }));
-      await vm.loadActiveProgram('client1');
-
-      expect(vm.activeProgramProgress).toBe(50);
-    });
-
-    it('returns 100 when all sessions are used', async () => {
-      mockProgramModel.getActiveProgram.mockResolvedValue(makeActiveProgram({ usedSessions: 20, totalSessions: 20 }));
-      await vm.loadActiveProgram('client1');
-
-      expect(vm.activeProgramProgress).toBe(100);
-    });
-  });
-
-  describe('hasLowSessions (computed)', () => {
-    it('returns false when there is no active program', () => {
-      expect(vm.hasLowSessions).toBe(false);
-    });
-
-    it('returns true when fewer than 3 sessions remain', async () => {
-      mockProgramModel.getActiveProgram.mockResolvedValue(makeActiveProgram({ usedSessions: 18, totalSessions: 20 }));
-      await vm.loadActiveProgram('client1');
-
-      expect(vm.hasLowSessions).toBe(true);
-    });
-
-    it('returns false when exactly 3 sessions remain', async () => {
-      mockProgramModel.getActiveProgram.mockResolvedValue(makeActiveProgram({ usedSessions: 17, totalSessions: 20 }));
-      await vm.loadActiveProgram('client1');
-
-      expect(vm.hasLowSessions).toBe(false);
-    });
-
-    it('returns false when 0 sessions remain (completed)', async () => {
-      mockProgramModel.getActiveProgram.mockResolvedValue(makeActiveProgram({ usedSessions: 20, totalSessions: 20 }));
-      await vm.loadActiveProgram('client1');
-
-      expect(vm.hasLowSessions).toBe(false);
-    });
-  });
-
-  describe('hasActiveProgram (computed)', () => {
-    it('returns false when no program loaded', () => {
-      expect(vm.hasActiveProgram).toBe(false);
-    });
-
-    it('returns true when active program is loaded', async () => {
-      mockProgramModel.getActiveProgram.mockResolvedValue(makeActiveProgram());
-      await vm.loadActiveProgram('client1');
-
-      expect(vm.hasActiveProgram).toBe(true);
-    });
-
-    it('returns false for an expired program', async () => {
-      mockProgramModel.getActiveProgram.mockResolvedValue(makeActiveProgram({ status: 'expired' }));
-      await vm.loadActiveProgram('client1');
-
-      expect(vm.hasActiveProgram).toBe(false);
-    });
-  });
-
   describe('createBooking', () => {
     const setupForBooking = async () => {
       mockBookingModel.getTrainers.mockResolvedValue([mockTrainer]);
@@ -192,7 +53,7 @@ describe('BookingViewModel', () => {
       vm.setZone('gym');
     };
 
-    it('delegates session consumption to ProgramModel and reloads program after a successful booking', async () => {
+    it('delegates session consumption to ProgramModel after a successful booking', async () => {
       await setupForBooking();
 
       const createdBooking: Booking = {
@@ -207,20 +68,16 @@ describe('BookingViewModel', () => {
         status: 'confirmed'
       };
 
-      const programAfter = makeActiveProgram({ usedSessions: 6 });
-
       mockBookingModel.createBooking.mockResolvedValue(createdBooking);
-      mockProgramModel.consumeSessionForClient.mockResolvedValue(programAfter);
-      mockProgramModel.getActiveProgram.mockResolvedValue(programAfter);
+      mockProgramModel.consumeSessionForClient.mockResolvedValue(undefined);
 
       const success = await vm.createBooking();
 
       expect(success).toBe(true);
       expect(mockProgramModel.consumeSessionForClient).toHaveBeenCalledWith('client1');
-      expect(vm.activeProgram?.usedSessions).toBe(6);
     });
 
-    it('succeeds and reloads program even when client has no active program', async () => {
+    it('succeeds when client has no active program', async () => {
       await setupForBooking();
 
       const createdBooking: Booking = {
@@ -237,13 +94,11 @@ describe('BookingViewModel', () => {
 
       mockBookingModel.createBooking.mockResolvedValue(createdBooking);
       mockProgramModel.consumeSessionForClient.mockResolvedValue(null);
-      mockProgramModel.getActiveProgram.mockResolvedValue(null);
 
       const success = await vm.createBooking();
 
       expect(success).toBe(true);
       expect(mockProgramModel.consumeSessionForClient).toHaveBeenCalledWith('client1');
-      expect(vm.activeProgram).toBeNull();
     });
 
     it('does not call consumeSessionForClient when booking fails', async () => {
@@ -291,7 +146,6 @@ describe('BookingViewModel', () => {
 
       mockBookingModel.createBooking.mockResolvedValue(createdBooking);
       mockProgramModel.consumeSessionForClient.mockResolvedValue(null);
-      mockProgramModel.getActiveProgram.mockResolvedValue(null);
 
       // BookingModel says ok — ViewModel must trust Model, not its own stale cache
       const success = await vm.createBooking();


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removes `activeProgram`, `loadActiveProgram()`, and 4 computed values (`pendingSessions`, `hasActiveProgram`, `activeProgramProgress`, `hasLowSessions`) from `BookingViewModel` — these duplicated state already owned by `ProgramViewModel`
- `ProgramSessionInfo` in `BookingView` now reads from `useProgramViewModel()` instead of `useBookingViewModel()`
- `BookingView` calls `programVM.loadActiveProgram()` on mount and after a successful booking to keep `ProgramViewModel` current
- `BookingViewModel` retains `ProgramModel` only for `consumeSessionForClient()` (called during booking creation)
- `BookingViewModel.test.ts` updated: removed 5 describe blocks that covered deleted functionality; updated `createBooking` tests to remove stale `activeProgram` assertions

## Test plan

- [ ] Create a booking as a client — success modal appears, program session count updates correctly in the confirmation section
- [ ] `ProgramSessionInfo` shows low-session warning when ≤ 2 sessions remain after booking
- [ ] CI: `BookingViewModel.test.ts` passes (5 removed describe blocks, 2 updated `createBooking` tests)
- [ ] CI: `npm run build` passes without TypeScript errors

Closes #68

https://claude.ai/code/session_01K8VxzUriMSjACtkdfpLRVF
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8VxzUriMSjACtkdfpLRVF)_