### PR TITLE
refactor(#64): decouple ClientProgramView from BookingViewModel

### DIFF
--- a/src/components/ClientProgramView.tsx
+++ b/src/components/ClientProgramView.tsx
@@ -2,24 +2,16 @@
 
 import React, { useEffect } from 'react';
 import { observer } from 'mobx-react-lite';
-import { useProgramViewModel, useBookingViewModel } from '@/core/providers/ViewModelProvider';
+import { useProgramViewModel } from '@/core/providers/ViewModelProvider';
 
 const MINIMUM_SESSIONS_FOR_RESULTS = 12;
 
 const ClientProgramView = observer(() => {
   const vm = useProgramViewModel();
-  const bookingVM = useBookingViewModel();
 
   useEffect(() => {
     vm.loadActiveProgram('client1');
   }, [vm]);
-
-  // Recargar el programa cuando se confirma una reserva
-  useEffect(() => {
-    if (bookingVM.confirmedBooking) {
-      vm.loadActiveProgram('client1');
-    }
-  }, [bookingVM.confirmedBooking, vm]);
 
   if (!vm.hasActiveProgram || !vm.activeProgram) {
     return null;


### PR DESCRIPTION
## Summary

- Removes the cross-domain coupling in `ClientProgramView`: it was importing `useBookingViewModel` solely to watch `confirmedBooking` and trigger a `ProgramViewModel` reload
- This coupling is now redundant: `BookingView.handleConfirmBooking()` already calls `programVM.loadActiveProgram()` after a successful booking (added in #118), and since `ProgramViewModel` is a shared MobX singleton in context, `ClientProgramView` receives the update reactively as an `observer`
- `ClientProgramView` now depends only on `useProgramViewModel()` — the correct single source of truth for program state

## Why this works without the useEffect

`ViewModelProvider` creates one `ProgramViewModel` instance shared across the entire app. When `BookingView` calls `programVM.loadActiveProgram()` post-booking, MobX marks the observable state as changed and all `observer` components subscribed to that state (including `ClientProgramView`) re-render automatically. No explicit cross-domain wiring is needed.

## Test plan

- [ ] Book a session as a client — verify `ClientProgramView`'s session count and progress bar update after the success modal closes
- [ ] Verify `ClientProgramView` does not import or reference `useBookingViewModel`
- [ ] CI: `npm run build` passes without TypeScript errors

Closes #64

https://claude.ai/code/session_01K8VxzUriMSjACtkdfpLRVF


---
_Generated by [Claude Code](https://claude.ai/code/session_01K8VxzUriMSjACtkdfpLRVF)_