### PR TITLE
refactor: remove MVVM violations from DataProvider

### DIFF
--- a/src/core/providers/DataProvider.tsx
+++ b/src/core/providers/DataProvider.tsx
@@ -3,7 +3,6 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { IDataService } from '../repositories';
 import { LocalStorageDataService } from '../repositories/localStorage';
-import { Trainer, Booking, Client, Program } from '../types';
 
 // Internal context — only for use by ViewModelProvider to access the service layer
 const DataServiceContext = createContext<IDataService | null>(null);
@@ -16,114 +15,32 @@ export function useDataService(): IDataService {
   return context;
 }
 
-interface DataContextType {
-  clients: Client[];
-  trainers: Trainer[];
-  bookings: Booking[];
-  programs: Program[];
-  isLoading: boolean;
-  refreshClients: () => Promise<void>;
-  refreshTrainers: () => Promise<void>;
-  refreshBookings: () => Promise<void>;
-  refreshPrograms: () => Promise<void>;
-}
-
-const DataContext = createContext<DataContextType | null>(null);
-
-export function useData(): DataContextType {
-  const context = useContext(DataContext);
-  if (!context) {
-    throw new Error('useData must be used within a DataProvider');
-  }
-  return context;
-}
-
 interface DataProviderProps {
   children: ReactNode;
 }
 
 export function DataProvider({ children }: DataProviderProps) {
   const [service] = useState<IDataService>(() => new LocalStorageDataService());
-  const [clients, setClients] = useState<Client[]>([]);
-  const [trainers, setTrainers] = useState<Trainer[]>([]);
-  const [bookings, setBookings] = useState<Booking[]>([]);
-  const [programs, setPrograms] = useState<Program[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-
-  const refreshClients = async () => {
-    try {
-      const data = await service.clients.getAll();
-      setClients(data);
-    } catch (error) {
-      console.error('Error loading clients:', error);
-    }
-  };
-
-  const refreshTrainers = async () => {
-    try {
-      const data = await service.trainers.getAll();
-      setTrainers(data);
-    } catch (error) {
-      console.error('Error loading trainers:', error);
-    }
-  };
-
-  const refreshBookings = async () => {
-    try {
-      const data = await service.bookings.getAll();
-      setBookings(data);
-    } catch (error) {
-      console.error('Error loading bookings:', error);
-    }
-  };
-
-  const refreshPrograms = async () => {
-    try {
-      const data = await service.programs.getAll();
-      setPrograms(data);
-    } catch (error) {
-      console.error('Error loading programs:', error);
-    }
-  };
+  const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
-    const initializeData = async () => {
-      setIsLoading(true);
-      try {
-        await service.initialize();
-        await Promise.all([
-          refreshClients(),
-          refreshTrainers(),
-          refreshBookings(),
-          refreshPrograms()
-        ]);
-      } catch (error) {
-        console.error('Error initializing data:', error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    initializeData();
+    service.initialize().then(() => setIsReady(true));
   }, [service]);
 
-  const value: DataContextType = {
-    clients,
-    trainers,
-    bookings,
-    programs,
-    isLoading,
-    refreshClients,
-    refreshTrainers,
-    refreshBookings,
-    refreshPrograms,
-  };
+  if (!isReady) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+          <p className="text-gray-600">Cargando...</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <DataServiceContext.Provider value={service}>
-      <DataContext.Provider value={value}>
-        {children}
-      </DataContext.Provider>
+      {children}
     </DataServiceContext.Provider>
   );
 }

--- a/tests/integration/BookingFlow.integration.test.ts
+++ b/tests/integration/BookingFlow.integration.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Integration tests: BookingModel ↔ LocalStorageDataService
+ *
+ * Exercises the full booking flow from ViewModel/Model down to the real
+ * LocalStorageDataService (backed by jsdom's localStorage), with no mocks of
+ * the persistence layer.
+ *
+ * Checklist (CLAUDE.md §6):
+ * - [x] Flujo completo ViewModel → Model → Repository con datos reales
+ * - [x] Comportamiento de LocalStorageDataService con BookingModel
+ * - [x] Estado de localStorage limpiado entre tests
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { LocalStorageDataService } from '@/core/repositories/localStorage';
+import { BookingModel } from '@/core/models/BookingModel';
+import { BookingViewModel } from '@/core/view-models/BookingViewModel';
+import { ProgramModel } from '@/core/models/ProgramModel';
+import { Booking, ZoneType } from '@/core/types';
+import { BookingCapacityError, BookingValidationError } from '@/core/types/errors';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tomorrow(): Date {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  d.setHours(12, 0, 0, 0);
+  return d;
+}
+
+function validBookingData(overrides: Partial<Omit<Booking, 'id'>> = {}): Omit<Booking, 'id'> {
+  return {
+    clientId: 'client1',
+    trainerId: 'trainer1',
+    trainerName: 'Entrenador Diego Lamas',
+    date: tomorrow(),
+    time: '09:00',
+    duration: 60,
+    zone: 'gym' as ZoneType,
+    status: 'confirmed',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+let service: LocalStorageDataService;
+let model: BookingModel;
+
+beforeEach(async () => {
+  localStorage.clear();
+  service = new LocalStorageDataService();
+  await service.initialize();
+  model = new BookingModel(service);
+});
+
+// ---------------------------------------------------------------------------
+// BookingModel ↔ LocalStorageDataService
+// ---------------------------------------------------------------------------
+
+describe('BookingModel ↔ LocalStorageDataService', () => {
+  describe('createBooking', () => {
+    it('persiste una reserva nueva en localStorage', async () => {
+      const booking = await model.createBooking(validBookingData());
+
+      expect(booking.id).toBeDefined();
+      const saved = await service.bookings.getById(booking.id);
+      expect(saved).not.toBeNull();
+      expect(saved!.clientId).toBe('client1');
+      expect(saved!.zone).toBe('gym');
+      expect(saved!.status).toBe('confirmed');
+    });
+
+    it('la reserva creada tiene id único', async () => {
+      const b1 = await model.createBooking(validBookingData({ clientId: 'client1', zone: 'gym' }));
+      const b2 = await model.createBooking(validBookingData({ clientId: 'client2', zone: 'gym' }));
+
+      expect(b1.id).not.toBe(b2.id);
+    });
+
+    it('lanza BookingValidationError si el cliente está vacío', async () => {
+      await expect(
+        model.createBooking(validBookingData({ clientId: '' }))
+      ).rejects.toThrow(BookingValidationError);
+    });
+
+    it('lanza BookingValidationError si la fecha es pasada', async () => {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+
+      await expect(
+        model.createBooking(validBookingData({ date: yesterday }))
+      ).rejects.toThrow(BookingValidationError);
+    });
+
+    it('lanza BookingValidationError si la duración es menor a 30 minutos', async () => {
+      await expect(
+        model.createBooking(validBookingData({ duration: 20 }))
+      ).rejects.toThrow(BookingValidationError);
+    });
+  });
+
+  describe('getBookingsByDate', () => {
+    it('retorna solo las reservas del día indicado', async () => {
+      const targetDate = tomorrow();
+      await model.createBooking(validBookingData({ date: targetDate, clientId: 'client1', zone: 'gym' }));
+      await model.createBooking(validBookingData({ date: targetDate, clientId: 'client2', zone: 'gym' }));
+
+      const otherDate = new Date(targetDate);
+      otherDate.setDate(otherDate.getDate() + 1);
+      await model.createBooking(validBookingData({ date: otherDate, clientId: 'client3', zone: 'gym' }));
+
+      const results = await model.getBookingsByDate(targetDate);
+      // Las reservas devueltas son solo del targetDate (las de initialData pueden incluirse si coincide)
+      const newOnes = results.filter(b => b.clientId === 'client1' || b.clientId === 'client2');
+      expect(newOnes).toHaveLength(2);
+      const wrongDate = results.filter(b => b.clientId === 'client3');
+      expect(wrongDate).toHaveLength(0);
+    });
+  });
+
+  describe('getAllBookings', () => {
+    it('retorna todas las reservas incluyendo las de initialData', async () => {
+      const before = (await model.getAllBookings()).length;
+      await model.createBooking(validBookingData({ clientId: 'client1', zone: 'gym' }));
+      const after = await model.getAllBookings();
+
+      expect(after.length).toBe(before + 1);
+    });
+  });
+
+  describe('getZoneOccupancy', () => {
+    it('cuenta correctamente las reservas confirmadas en la zona gym', async () => {
+      const date = tomorrow();
+      const time = '09:00';
+
+      await model.createBooking(validBookingData({ date, time, clientId: 'client1', zone: 'gym' }));
+      await model.createBooking(validBookingData({ date, time, clientId: 'client2', zone: 'gym' }));
+
+      const occupancy = await model.getZoneOccupancy('gym', date, time, 'trainer1');
+      expect(occupancy).toBe(2);
+    });
+
+    it('no cuenta reservas canceladas en el aforo', async () => {
+      const date = tomorrow();
+      const time = '09:00';
+
+      // Insertar directamente una reserva cancelada (sin pasar por createBooking)
+      await service.bookings.create({
+        clientId: 'client9',
+        trainerId: 'trainer1',
+        trainerName: 'Entrenador Diego Lamas',
+        date,
+        time,
+        duration: 60,
+        zone: 'gym',
+        status: 'cancelled',
+      });
+      await model.createBooking(validBookingData({ date, time, clientId: 'client1', zone: 'gym' }));
+
+      const occupancy = await model.getZoneOccupancy('gym', date, time, 'trainer1');
+      expect(occupancy).toBe(1); // Solo la confirmada
+    });
+
+    it('gabinete tiene aforo global — no distingue por trainerId', async () => {
+      const date = tomorrow();
+      const time = '10:00';
+
+      await model.createBooking(validBookingData({ date, time, trainerId: 'trainer1', clientId: 'client1', zone: 'gabinete' }));
+
+      const occupancyWithTrainer = await model.getZoneOccupancy('gabinete', date, time, 'trainer1');
+      const occupancyGlobal = await model.getZoneOccupancy('gabinete', date, time);
+      expect(occupancyWithTrainer).toBe(occupancyGlobal);
+    });
+  });
+
+  describe('validación de capacidad (BookingCapacityError)', () => {
+    it('lanza BookingCapacityError cuando el gabinete está lleno (capacidad 1)', async () => {
+      const date = tomorrow();
+      const time = '10:00';
+
+      // Llenar el gabinete (capacidad máxima = 1)
+      await model.createBooking(validBookingData({ date, time, clientId: 'client1', zone: 'gabinete' }));
+
+      // El segundo intento debe lanzar error de capacidad
+      await expect(
+        model.createBooking(validBookingData({ date, time, clientId: 'client2', zone: 'gabinete' }))
+      ).rejects.toThrow(BookingCapacityError);
+    });
+
+    it('gym permite múltiples reservas hasta su capacidad máxima (10)', async () => {
+      const date = tomorrow();
+      const time = '11:00';
+
+      // gym tiene capacidad 10 — deben caber 2 sin error
+      await model.createBooking(validBookingData({ date, time, clientId: 'client1', zone: 'gym' }));
+      const booking2 = await model.createBooking(
+        validBookingData({ date, time, clientId: 'client2', zone: 'gym' })
+      );
+      expect(booking2.id).toBeDefined();
+    });
+
+    it('reservas en gym no bloquean el gabinete ni viceversa', async () => {
+      const date = tomorrow();
+      const time = '12:00';
+
+      await model.createBooking(validBookingData({ date, time, clientId: 'client1', zone: 'gym' }));
+      // El gabinete sigue disponible aunque gym tenga reservas
+      const gabinete = await model.createBooking(
+        validBookingData({ date, time, clientId: 'client2', zone: 'gabinete' })
+      );
+      expect(gabinete.zone).toBe('gabinete');
+    });
+  });
+
+  describe('flujo completo: crear → verificar persistencia → aforo', () => {
+    it('ejecuta el ciclo de vida de una reserva de principio a fin', async () => {
+      const date = tomorrow();
+      const time = '09:00';
+
+      // 1. Crear reserva
+      const booking = await model.createBooking(
+        validBookingData({ date, time, clientId: 'client1', zone: 'gym' })
+      );
+      expect(booking.id).toBeDefined();
+      expect(booking.status).toBe('confirmed');
+
+      // 2. Verificar que persiste en localStorage
+      const saved = await service.bookings.getById(booking.id);
+      expect(saved).not.toBeNull();
+      expect(saved!.clientId).toBe('client1');
+
+      // 3. Verificar que aparece en getBookingsByDate
+      const dayBookings = await model.getBookingsByDate(date);
+      expect(dayBookings.some(b => b.id === booking.id)).toBe(true);
+
+      // 4. Verificar que el aforo refleja la nueva reserva
+      const occupancy = await model.getZoneOccupancy('gym', date, time, 'trainer1');
+      expect(occupancy).toBeGreaterThanOrEqual(1);
+
+      // 5. Verificar aforo de ambas zonas a la vez
+      const both = await model.getAllZonesOccupancy(date, time, 'trainer1');
+      expect(both.gym).toBeGreaterThanOrEqual(1);
+      expect(typeof both.gabinete).toBe('number');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BookingViewModel ↔ BookingModel ↔ LocalStorageDataService
+// ---------------------------------------------------------------------------
+
+describe('BookingViewModel ↔ BookingModel ↔ LocalStorageDataService', () => {
+  let vm: BookingViewModel;
+
+  beforeEach(() => {
+    const programModel = new ProgramModel(service);
+    vm = new BookingViewModel(model, programModel);
+  });
+
+  it('createBooking a través del ViewModel persiste en localStorage', async () => {
+    await vm.loadTrainers();
+    expect(vm.trainers.length).toBeGreaterThan(0);
+
+    const trainer = vm.trainers[0];
+    const date = tomorrow();
+
+    vm.setDate(date);
+    vm.setTrainer(trainer.id);
+    await vm.loadAvailableSlots(trainer.id, date);
+
+    // Usar un slot disponible si existe; si no hay (domingo), saltar test
+    if (vm.availableSlots.length === 0) return;
+
+    vm.setTime(vm.availableSlots[0]);
+    vm.setZone('gym');
+
+    const success = await vm.createBooking();
+
+    expect(success).toBe(true);
+    expect(vm.error).toBeNull();
+    expect(vm.showSuccessModal).toBe(true);
+    expect(vm.confirmedBooking).not.toBeNull();
+
+    // Verificar persistencia real en localStorage
+    const saved = await service.bookings.getById(vm.confirmedBooking!.id);
+    expect(saved).not.toBeNull();
+    expect(saved!.zone).toBe('gym');
+  });
+
+  it('createBooking falla con error de dominio si el gabinete está lleno', async () => {
+    await vm.loadTrainers();
+    const trainer = vm.trainers[0];
+    const date = tomorrow();
+
+    vm.setDate(date);
+    vm.setTrainer(trainer.id);
+    await vm.loadAvailableSlots(trainer.id, date);
+
+    if (vm.availableSlots.length === 0) return;
+
+    const time = vm.availableSlots[0];
+
+    // Llenar el gabinete directamente vía el service (capacidad 1)
+    await service.bookings.create({
+      clientId: 'client9',
+      trainerId: trainer.id,
+      trainerName: `Entrenador ${trainer.name}`,
+      date,
+      time,
+      duration: 60,
+      zone: 'gabinete',
+      status: 'confirmed',
+    });
+
+    vm.setTime(time);
+    vm.setZone('gabinete');
+
+    const success = await vm.createBooking();
+
+    expect(success).toBe(false);
+    expect(vm.error).not.toBeNull();
+    expect(vm.showSuccessModal).toBe(false);
+  });
+
+  it('refreshBookings actualiza la lista de reservas después de crear una', async () => {
+    await vm.loadTrainers();
+    const trainer = vm.trainers[0];
+    const date = tomorrow();
+
+    vm.setDate(date);
+    vm.setTrainer(trainer.id);
+    await vm.loadAvailableSlots(trainer.id, date);
+
+    if (vm.availableSlots.length === 0) return;
+
+    vm.setTime(vm.availableSlots[0]);
+    vm.setZone('gym');
+
+    const before = vm.bookings.length;
+    await vm.createBooking();
+    await vm.refreshBookings();
+
+    expect(vm.bookings.length).toBeGreaterThan(before);
+  });
+});

--- a/tests/integration/BookingFlow.integration.test.ts
+++ b/tests/integration/BookingFlow.integration.test.ts
@@ -206,7 +206,7 @@ describe('BookingModel ↔ LocalStorageDataService', () => {
 
     it('reservas en gym no bloquean el gabinete ni viceversa', async () => {
       const date = tomorrow();
-      const time = '12:00';
+      const time = '16:00'; // '12:00' no está disponible en el horario de trainer1
 
       await model.createBooking(validBookingData({ date, time, clientId: 'client1', zone: 'gym' }));
       // El gabinete sigue disponible aunque gym tenga reservas

--- a/tests/integration/DataProvider.integration.test.ts
+++ b/tests/integration/DataProvider.integration.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Integration tests: DataProvider initialization contract
+ *
+ * These tests guard the functional behavior that DataProvider is responsible
+ * for: calling service.initialize() to seed demo data and providing a working
+ * IDataService to the ViewModel layer.
+ *
+ * After the DataProvider cleanup (removing React state / useData()), these
+ * tests ensure the initialization chain still works correctly.
+ *
+ * Checklist (CLAUDE.md §6):
+ * - [x] Flujo Model → Repository con datos reales (sin mocks de persistencia)
+ * - [x] Comportamiento de LocalStorageDataService.initialize()
+ * - [x] Estado de localStorage limpiado entre tests
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { LocalStorageDataService } from '@/core/repositories/localStorage';
+import { BookingModel } from '@/core/models/BookingModel';
+import { BookingViewModel } from '@/core/view-models/BookingViewModel';
+import { ProgramModel } from '@/core/models/ProgramModel';
+import { ClientModel } from '@/core/models/ClientModel';
+import { ClientViewModel } from '@/core/view-models/ClientViewModel';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+// ---------------------------------------------------------------------------
+// service.initialize() — comportamiento que DataProvider encapsula
+// ---------------------------------------------------------------------------
+
+describe('LocalStorageDataService.initialize()', () => {
+  it('siembra entrenadores demo cuando localStorage está vacío', async () => {
+    const service = new LocalStorageDataService();
+    await service.initialize();
+
+    const trainers = await service.trainers.getAll();
+    expect(trainers.length).toBeGreaterThanOrEqual(1);
+    expect(trainers[0].id).toBeDefined();
+    expect(trainers[0].name).toBeDefined();
+  });
+
+  it('siembra horarios de entrenadores junto con los entrenadores', async () => {
+    const service = new LocalStorageDataService();
+    await service.initialize();
+
+    const trainers = await service.trainers.getAll();
+    // Cada entrenador debe tener horario configurado después de initialize()
+    for (const trainer of trainers) {
+      const schedule = await service.trainers.getSchedule(trainer.id);
+      expect(schedule).not.toBeNull();
+      expect(schedule!.weeklySchedule.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('es idempotente — llamarla dos veces no duplica los datos', async () => {
+    const service = new LocalStorageDataService();
+    await service.initialize();
+    const countAfterFirst = (await service.trainers.getAll()).length;
+
+    await service.initialize();
+    const countAfterSecond = (await service.trainers.getAll()).length;
+
+    expect(countAfterSecond).toBe(countAfterFirst);
+  });
+
+  it('no borra datos existentes en localStorage si ya hay entrenadores', async () => {
+    const service = new LocalStorageDataService();
+    await service.initialize();
+    const trainers = await service.trainers.getAll();
+    const originalId = trainers[0].id;
+
+    // Segunda inicialización no debe sobrescribir
+    const service2 = new LocalStorageDataService();
+    await service2.initialize();
+    const trainers2 = await service2.trainers.getAll();
+
+    expect(trainers2.find(t => t.id === originalId)).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BookingViewModel ↔ BookingModel ↔ service inicializado
+// (cadena que DataProvider habilita al proveer el service)
+// ---------------------------------------------------------------------------
+
+describe('BookingViewModel con service inicializado', () => {
+  let service: LocalStorageDataService;
+  let bookingVM: BookingViewModel;
+
+  beforeEach(async () => {
+    service = new LocalStorageDataService();
+    await service.initialize(); // simula lo que DataProvider hace al montar
+    const bookingModel = new BookingModel(service);
+    const programModel = new ProgramModel(service);
+    bookingVM = new BookingViewModel(bookingModel, programModel);
+  });
+
+  it('loadTrainers carga los entrenadores sembrados por initialize()', async () => {
+    await bookingVM.loadTrainers();
+
+    expect(bookingVM.trainers.length).toBeGreaterThanOrEqual(1);
+    expect(bookingVM.error).toBeNull();
+    expect(bookingVM.isLoading).toBe(false);
+  });
+
+  it('después de loadTrainers los slots disponibles se pueden cargar para una fecha futura', async () => {
+    await bookingVM.loadTrainers();
+
+    const trainer = bookingVM.trainers[0];
+    const nextMonday = getNextWeekday(1); // próximo lunes
+
+    await bookingVM.loadAvailableSlots(trainer.id, nextMonday);
+
+    // Con horario sembrado, debe haber slots disponibles en días laborables
+    expect(Array.isArray(bookingVM.availableSlots)).toBe(true);
+    expect(bookingVM.error).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ClientViewModel ↔ ClientModel ↔ service inicializado
+// ---------------------------------------------------------------------------
+
+describe('ClientViewModel con service inicializado', () => {
+  it('loadClients carga los clientes demo del service', async () => {
+    const service = new LocalStorageDataService();
+    // Los clientes se cargan con datos por defecto aunque initialize() no los siembra
+    // (LocalStorageDataService los devuelve desde initialData cuando localStorage está vacío)
+    const clientModel = new ClientModel(service);
+    const clientVM = new ClientViewModel(clientModel);
+
+    await clientVM.loadClients();
+
+    expect(clientVM.clients.length).toBeGreaterThanOrEqual(1);
+    expect(clientVM.isLoading).toBe(false);
+    expect(clientVM.error).toBeNull();
+  });
+
+  it('getClientName resuelve el nombre correcto después de loadClients', async () => {
+    const service = new LocalStorageDataService();
+    const clientVM = new ClientViewModel(new ClientModel(service));
+
+    await clientVM.loadClients();
+    const firstClient = clientVM.clients[0];
+
+    expect(clientVM.getClientName(firstClient.id)).toBe(firstClient.name);
+  });
+
+  it('getClientName retorna el id si el cliente no existe', async () => {
+    const service = new LocalStorageDataService();
+    const clientVM = new ClientViewModel(new ClientModel(service));
+    await clientVM.loadClients();
+
+    expect(clientVM.getClientName('id_inexistente')).toBe('id_inexistente');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getNextWeekday(dayOfWeek: number): Date {
+  const date = new Date();
+  const currentDay = date.getDay();
+  const daysUntilTarget = (dayOfWeek - currentDay + 7) % 7 || 7;
+  date.setDate(date.getDate() + daysUntilTarget);
+  date.setHours(12, 0, 0, 0);
+  return date;
+}


### PR DESCRIPTION
## Problema

`DataProvider` tenía dos violaciones del patrón MVVM:

1. **Estado de datos de dominio en React state** — mantenía `clients`, `trainers`, `bookings`, `programs` y funciones `refresh*` propias, duplicando lo que los ViewModels ya gestionan.
2. **`DataContext` / `useData()` muertos** — infraestructura sin consumidores (ningún componente llama `useData()` desde la fase 2 de refactoring).

## Solución

`DataProvider` ahora tiene una única responsabilidad:

```
DataProvider
  ├── Crea LocalStorageDataService           ✅ (infraestructura)
  ├── Llama service.initialize()             ✅ (siembra datos demo)
  ├── Muestra pantalla de carga hasta ready  ✅
  └── Expone service via DataServiceContext  ✅ (solo para ViewModelProvider)
```

## Cambios

**Eliminado (~90 líneas):**
- `DataContextType`, `DataContext`, `useData()`
- React state para `clients`, `trainers`, `bookings`, `programs`
- `refreshClients`, `refreshTrainers`, `refreshBookings`, `refreshPrograms`
- Imports de `Trainer`, `Booking`, `Client`, `Program`

**Agregado (tests de integración):**
- `tests/integration/DataProvider.integration.test.ts` — guarda el contrato de `service.initialize()` (siembra, idempotencia, cadena ViewModel)
- `tests/integration/BookingFlow.integration.test.ts` — cubre `BookingModel ↔ LocalStorageDataService` completo (crear, persistir, aforo, capacidad, flujo ViewModel)

## Test plan

- [ ] CI: tests de integración pasan (`DataProvider.integration.test.ts`, `BookingFlow.integration.test.ts`)
- [ ] CI: `npm run build` sin errores TypeScript
- [ ] App carga correctamente — pantalla de inicio muestra spinner hasta que `initialize()` completa
- [ ] Flujo de reserva completo funciona (clientes, entrenadores, zonas)
- [ ] Vista del entrenador carga citas correctamente

https://claude.ai/code/session_01K8VxzUriMSjACtkdfpLRVF


---
_Generated by [Claude Code](https://claude.ai/code/session_01K8VxzUriMSjACtkdfpLRVF)_