### PR TITLE
fix: Supabase CLI flag --project-ref → supabase link + --linked

### DIFF
--- a/.github/workflows/supabase-migrate.yml
+++ b/.github/workflows/supabase-migrate.yml
@@ -13,6 +13,7 @@ on:
     branches: [main, master]
     paths:
       - 'supabase/migrations/**'
+  workflow_dispatch:
 
 jobs:
   validate:

--- a/.github/workflows/supabase-migrate.yml
+++ b/.github/workflows/supabase-migrate.yml
@@ -32,8 +32,14 @@ jobs:
         with:
           version: latest
 
+      - name: Link Supabase project
+        run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_ID }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
       - name: Apply migrations to production
-        run: supabase db push --project-ref ${{ secrets.SUPABASE_PROJECT_ID }}
+        run: supabase db push --linked
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}


### PR DESCRIPTION
## Problema

El workflow `supabase-migrate.yml` fallaba con:
```
Unrecognized flag: --project-ref in command supabase db push
```

La CLI de Supabase eliminó `--project-ref` de `db push` en versiones recientes.

## Fix

El flujo correcto ahora es:
```bash
supabase link --project-ref <ref>   # vincula el proyecto
supabase db push --linked           # aplica migraciones al proyecto vinculado
```

## Cambio

```diff
- run: supabase db push --project-ref ${{ secrets.SUPABASE_PROJECT_ID }}
+ run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_ID }}
+ run: supabase db push --linked
```

Los mismos 3 secrets siguen siendo necesarios: `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_ID`, `SUPABASE_DB_PASSWORD`.

🤖 Generated with [Claude Code](https://claude.ai/code/session_01QLt6xhMZPQZntXLtbSSszH)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLt6xhMZPQZntXLtbSSszH)_