### PR TITLE
fix(seed): remove phone columns from auth.users inserts

### DIFF
--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -21,9 +21,10 @@
 -- ============================================================
 -- 1. Auth users — Entrenadores
 --
--- GoTrue requires empty string '' (not NULL) for optional string
--- columns like email_change, phone, reauthentication_token, etc.
--- Inserting NULL in those columns causes a scan error on login.
+-- GoTrue requires '' (not NULL) for token string columns
+-- (email_change, confirmation_token, recovery_token, etc.).
+-- phone/phone_change/phone_change_token have a UNIQUE constraint
+-- so they must remain NULL (GoTrue scans them as *string).
 -- ============================================================
 INSERT INTO auth.users (
   instance_id, id, aud, role, email, encrypted_password,
@@ -32,7 +33,6 @@ INSERT INTO auth.users (
   is_super_admin,
   confirmation_token, recovery_token,
   email_change, email_change_token_new, email_change_token_current,
-  phone, phone_change, phone_change_token,
   reauthentication_token
 )
 VALUES
@@ -47,7 +47,6 @@ VALUES
     FALSE,
     '', '',
     '', '', '',
-    '', '', '',
     ''
   ),
   (
@@ -60,7 +59,6 @@ VALUES
     '{"role":"trainer","full_name":"Jeanpierre Casas"}',
     FALSE,
     '', '',
-    '', '', '',
     '', '', '',
     ''
   )
@@ -76,19 +74,18 @@ INSERT INTO auth.users (
   is_super_admin,
   confirmation_token, recovery_token,
   email_change, email_change_token_new, email_change_token_current,
-  phone, phone_change, phone_change_token,
   reauthentication_token
 )
 VALUES
-  ('00000000-0000-0000-0000-000000000000','cccccccc-0000-0000-0000-000000000001','authenticated','authenticated','maria.gonzalez@email.com', crypt('gym2026!', gen_salt('bf')),NOW(),NOW(),NOW(),'{"provider":"email","providers":["email"]}','{"role":"client","full_name":"María González"}',  FALSE,'','','','','','','','',''),
-  ('00000000-0000-0000-0000-000000000000','cccccccc-0000-0000-0000-000000000002','authenticated','authenticated','carlos.ruiz@email.com',     crypt('gym2026!', gen_salt('bf')),NOW(),NOW(),NOW(),'{"provider":"email","providers":["email"]}','{"role":"client","full_name":"Carlos Ruiz"}',      FALSE,'','','','','','','','',''),
-  ('00000000-0000-0000-0000-000000000000','cccccccc-0000-0000-0000-000000000003','authenticated','authenticated','ana.martin@email.com',      crypt('gym2026!', gen_salt('bf')),NOW(),NOW(),NOW(),'{"provider":"email","providers":["email"]}','{"role":"client","full_name":"Ana Martín"}',       FALSE,'','','','','','','','',''),
-  ('00000000-0000-0000-0000-000000000000','cccccccc-0000-0000-0000-000000000004','authenticated','authenticated','luis.torres@email.com',     crypt('gym2026!', gen_salt('bf')),NOW(),NOW(),NOW(),'{"provider":"email","providers":["email"]}','{"role":"client","full_name":"Luis Torres"}',      FALSE,'','','','','','','','',''),
-  ('00000000-0000-0000-0000-000000000000','cccccccc-0000-0000-0000-000000000005','authenticated','authenticated','patricia.vega@email.com',   crypt('gym2026!', gen_salt('bf')),NOW(),NOW(),NOW(),'{"provider":"email","providers":["email"]}','{"role":"client","full_name":"Patricia Vega"}',    FALSE,'','','','','','','','',''),
-  ('00000000-0000-0000-0000-000000000000','cccccccc-0000-0000-0000-000000000006','authenticated','authenticated','roberto.silva@email.com',   crypt('gym2026!', gen_salt('bf')),NOW(),NOW(),NOW(),'{"provider":"email","providers":["email"]}','{"role":"client","full_name":"Roberto Silva"}',    FALSE,'','','','','','','','',''),
-  ('00000000-0000-0000-0000-000000000000','cccccccc-0000-0000-0000-000000000007','authenticated','authenticated','laura.mendoza@email.com',   crypt('gym2026!', gen_salt('bf')),NOW(),NOW(),NOW(),'{"provider":"email","providers":["email"]}','{"role":"client","full_name":"Laura Mendoza"}',    FALSE,'','','','','','','','',''),
-  ('00000000-0000-0000-0000-000000000000','cccccccc-0000-0000-0000-000000000008','authenticated','authenticated','diego.castro@email.com',    crypt('gym2026!', gen_salt('bf')),NOW(),NOW(),NOW(),'{"provider":"email","providers":["email"]}','{"role":"client","full_name":"Diego Castro"}',     FALSE,'','','','','','','','',''),
-  ('00000000-0000-0000-0000-000000000000','cccccccc-0000-0000-0000-000000000009','authenticated','authenticated','luis.castillejo@email.com', crypt('gym2026!', gen_salt('bf')),NOW(),NOW(),NOW(),'{"provider":"email","providers":["email"]}','{"role":"client","full_name":"Luis Castillejo"}',  FALSE,'','','','','','','','','')
+  ('00000000-0000-0000-0000-000000000000','cccccccc-0000-0000-0000-000000000001','authenticated','authenticated','maria.gonzalez@email.com', crypt('gym2026!', gen_salt('bf')),NOW(),NOW(),NOW(),'{"provider":"email","providers":["email"]}','{"role":"client","full_name":"María González"}',  FALSE,'','','','','',''),
+  ('00000000-0000-0000-0000-000000000000','cccccccc-0000-0000-0000-000000000002','authenticated','authenticated','carlos.ruiz@email.com',     crypt('gym2026!', gen_salt('bf')),NOW(),NOW(),NOW(),'{"provider":"email","providers":["email"]}','{"role":"client","full_name":"Carlos Ruiz"}',      FALSE,'','','','','',''),
+  ('00000000-0000-0000-0000-000000000000','cccccccc-0000-0000-0000-000000000003','authenticated','authenticated','ana.martin@email.com',      crypt('gym2026!', gen_salt('bf')),NOW(),NOW(),NOW(),'{"provider":"email","providers":["email"]}','{"role":"client","full_name":"Ana Martín"}',       FALSE,'','','','','',''),
+  ('00000000-0000-0000-0000-000000000000','cccccccc-0000-0000-0000-000000000004','authenticated','authenticated','luis.torres@email.com',     crypt('gym2026!', gen_salt('bf')),NOW(),NOW(),NOW(),'{"provider":"email","providers":["email"]}','{"role":"client","full_name":"Luis Torres"}',      FALSE,'','','','','',''),
+  ('00000000-0000-0000-0000-000000000000','cccccccc-0000-0000-0000-000000000005','authenticated','authenticated','patricia.vega@email.com',   crypt('gym2026!', gen_salt('bf')),NOW(),NOW(),NOW(),'{"provider":"email","providers":["email"]}','{"role":"client","full_name":"Patricia Vega"}',    FALSE,'','','','','',''),
+  ('00000000-0000-0000-0000-000000000000','cccccccc-0000-0000-0000-000000000006','authenticated','authenticated','roberto.silva@email.com',   crypt('gym2026!', gen_salt('bf')),NOW(),NOW(),NOW(),'{"provider":"email","providers":["email"]}','{"role":"client","full_name":"Roberto Silva"}',    FALSE,'','','','','',''),
+  ('00000000-0000-0000-0000-000000000000','cccccccc-0000-0000-0000-000000000007','authenticated','authenticated','laura.mendoza@email.com',   crypt('gym2026!', gen_salt('bf')),NOW(),NOW(),NOW(),'{"provider":"email","providers":["email"]}','{"role":"client","full_name":"Laura Mendoza"}',    FALSE,'','','','','',''),
+  ('00000000-0000-0000-0000-000000000000','cccccccc-0000-0000-0000-000000000008','authenticated','authenticated','diego.castro@email.com',    crypt('gym2026!', gen_salt('bf')),NOW(),NOW(),NOW(),'{"provider":"email","providers":["email"]}','{"role":"client","full_name":"Diego Castro"}',     FALSE,'','','','','',''),
+  ('00000000-0000-0000-0000-000000000000','cccccccc-0000-0000-0000-000000000009','authenticated','authenticated','luis.castillejo@email.com', crypt('gym2026!', gen_salt('bf')),NOW(),NOW(),NOW(),'{"provider":"email","providers":["email"]}','{"role":"client","full_name":"Luis Castillejo"}',  FALSE,'','','','','','')
 ON CONFLICT (id) DO NOTHING;
 
 -- ============================================================


### PR DESCRIPTION
## Summary

- `phone`, `phone_change`, `phone_change_token` tienen un UNIQUE constraint en `auth.users` (`users_phone_key`), por lo que insertar `''` para múltiples usuarios causa `duplicate key value violates unique constraint`
- Estos campos son escaneados por GoTrue como `*string` (puntero), por lo que `NULL` es válido y no causa el error de login
- Se mantienen los campos de token (`email_change`, `confirmation_token`, `recovery_token`, `reauthentication_token`) como `''` ya que GoTrue los escanea como `string` (no puntero) y fallan con `NULL`

## Test plan

- [ ] Correr el UPDATE SQL en Supabase SQL Editor (sin las columnas de teléfono) y verificar login con `diego@nivel.gym` / `gym2026!`
- [ ] Verificar que `supabase db reset` completa sin errores en entorno local

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLt6xhMZPQZntXLtbSSszH

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLt6xhMZPQZntXLtbSSszH)_