### PR TITLE
fix: trainer schedule not persisting after re-login (#131)

### DIFF
--- a/src/core/services/SupabaseDataService.ts
+++ b/src/core/services/SupabaseDataService.ts
@@ -142,11 +142,15 @@ export class SupabaseTrainerRepository implements ITrainerRepository {
   }
 
   async getSchedule(trainerId: string): Promise<TrainerSchedule | null> {
+    // Only fetch rows from the current week onwards so stale past rows with
+    // is_available=true don't override slots that were later removed.
+    const weekStart = format(startOfWeek(new Date(), { weekStartsOn: 1 }), 'yyyy-MM-dd');
     const [scheduleResult, trainerResult] = await Promise.all([
       this.client
         .from('trainer_schedules')
         .select('*')
-        .eq('trainer_id', trainerId),
+        .eq('trainer_id', trainerId)
+        .gte('date', weekStart),
       this.client.from('trainers').select('name').eq('id', trainerId).single(),
     ]);
     if (scheduleResult.error) throw new Error(scheduleResult.error.message);

--- a/tests/unit/core/services/SupabaseDataService.test.ts
+++ b/tests/unit/core/services/SupabaseDataService.test.ts
@@ -23,6 +23,7 @@ function makeBuilder(result: { data: unknown; error: { message: string } | null 
   const builder: Record<string, unknown> = {
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
     insert: vi.fn().mockReturnThis(),
     single: vi.fn().mockResolvedValue(result),
     upsert: vi.fn().mockResolvedValue({ data: null, error: null }),


### PR DESCRIPTION
## Summary

- **Root cause**: `SupabaseTrainerRepository.getSchedule()` fetched ALL rows for the trainer with no date filter, including rows from past weeks. The `toDomain()` mapper merges availability with `current || row.is_available`, so any historical row with `is_available=true` for a slot would reappear even if the trainer removed it in their latest save.
- **Fix**: Added `.gte('date', weekStart)` filter to `getSchedule()` so it only reads rows from the current week onwards — matching the 4-week rolling window that `saveSchedule()` writes into.
- **Unchanged**: `saveSchedule()` already correctly upserts all slots (both `available: true` and `available: false`) for the full 4-week window via `onConflict: 'trainer_id,date,time_slot'`.

## Test plan

- [ ] Log in as a trainer and open "Registra tu disponibilidad"
- [ ] Set a schedule with several slots (e.g., Monday 09:00, 10:00, 11:00) and save
- [ ] Re-open the tab and confirm those slots are shown
- [ ] Remove slot(s) (e.g., uncheck 10:00 and 11:00) and save again
- [ ] Reload / log out and log back in → only 09:00 should be checked; 10:00 and 11:00 must not reappear

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBDHqbFNiFFQfqHK3yaFma

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBDHqbFNiFFQfqHK3yaFma)_