### PR TITLE
fix: do not pre-load a hardcoded trainer's schedule on first login

### DIFF
--- a/src/components/trainer/TrainerSchedule.tsx
+++ b/src/components/trainer/TrainerSchedule.tsx
@@ -34,14 +34,12 @@ const TrainerScheduleComponent = observer(function TrainerSchedule() {
   const currentSchedule = vm.currentSchedule;
 
   const [schedule, setSchedule] = useState<DaySchedule[]>(buildDefaultSchedule);
-  const [trainerName, setTrainerName] = useState('Diego Lamas');
+  const [trainerName, setTrainerName] = useState('');
   const [showSaveModal, setShowSaveModal] = useState(false);
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
-  const trainersToDisplay = vm.trainers.length > 0
-    ? vm.trainers
-    : [{ id: '', name: 'Diego Lamas' }, { id: '', name: 'Jeanpierre Casas' }];
+  const trainersToDisplay = vm.trainers;
 
   useEffect(() => {
     vm.loadTrainers();


### PR DESCRIPTION
## Summary

- `TrainerSchedule` initialised `trainerName` to `'Diego Lamas'`, which caused the component to load Diego's schedule for every new trainer on first login
- Changed the default state to `''` so no trainer is pre-selected
- Removed the hardcoded `[Diego Lamas, Jeanpierre Casas]` fallback list from `trainersToDisplay` so the dropdown stays empty while real data loads from the server

Fixes #140

## Test plan

- [ ] Log in as a brand-new trainer → schedule grid should start empty (all slots unselected, no pre-loaded schedule)
- [ ] Existing trainer selects their name from the dropdown → their saved schedule loads correctly
- [ ] Saving a schedule still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hh7Wp3ZYb7Q1smE3jzEhxF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hh7Wp3ZYb7Q1smE3jzEhxF)_