### PR TITLE
fix: use authenticated user UUID instead of hardcoded client1 in booking flow

### DIFF
--- a/src/components/ClientProgramView.tsx
+++ b/src/components/ClientProgramView.tsx
@@ -3,15 +3,20 @@
 import React, { useEffect } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useProgramViewModel } from '@/core/providers/ViewModelProvider';
+import { useAuthViewModel } from '@/core/providers/AuthProvider';
 
 const MINIMUM_SESSIONS_FOR_RESULTS = 12;
 
 const ClientProgramView = observer(() => {
   const vm = useProgramViewModel();
+  const authVM = useAuthViewModel();
 
   useEffect(() => {
-    vm.loadActiveProgram('client1');
-  }, [vm]);
+    const userId = authVM.currentUser?.id;
+    if (userId) {
+      vm.loadActiveProgram(userId);
+    }
+  }, [vm, authVM.currentUser]);
 
   if (!vm.hasActiveProgram || !vm.activeProgram) {
     return null;

--- a/src/core/providers/ViewModelProvider.tsx
+++ b/src/core/providers/ViewModelProvider.tsx
@@ -10,6 +10,7 @@ import { TrainerModel } from '../models/TrainerModel';
 import { ClientViewModel } from '../view-models/ClientViewModel';
 import { ClientModel } from '../models/ClientModel';
 import { useDataService } from './DataProvider';
+import { useAuthViewModel } from './AuthProvider';
 
 interface ViewModelContextType {
   bookingVM: BookingViewModel;
@@ -26,6 +27,7 @@ interface ViewModelProviderProps {
 
 export function ViewModelProvider({ children }: ViewModelProviderProps) {
   const service = useDataService();
+  const authVM = useAuthViewModel();
 
   const viewModels = useMemo(() => {
     const bookingModel = new BookingModel(service);
@@ -44,6 +46,10 @@ export function ViewModelProvider({ children }: ViewModelProviderProps) {
   useEffect(() => {
     viewModels.clientVM.loadClients();
   }, [viewModels]);
+
+  useEffect(() => {
+    viewModels.bookingVM.setClientId(authVM.currentUser?.id ?? '');
+  }, [authVM.currentUser, viewModels.bookingVM]);
 
   return (
     <ViewModelContext.Provider value={viewModels}>

--- a/src/core/view-models/BookingViewModel.ts
+++ b/src/core/view-models/BookingViewModel.ts
@@ -31,7 +31,7 @@ export class BookingViewModel {
   selectedTrainer: Trainer | null = null;
   selectedTime: string | null = null;
   selectedZone: ZoneType | null = null;
-  clientId = 'client1'; // En una app real vendría de un selector de clientes
+  clientId = '';
   
   // Estado de modales
   showSuccessModal = false;

--- a/tests/integration/BookingFlow.integration.test.ts
+++ b/tests/integration/BookingFlow.integration.test.ts
@@ -265,6 +265,7 @@ describe('BookingViewModel ↔ BookingModel ↔ LocalStorageDataService', () => 
   beforeEach(() => {
     const programModel = new ProgramModel(service);
     vm = new BookingViewModel(model, programModel);
+    vm.setClientId('client-test-uuid');
   });
 
   it('createBooking a través del ViewModel persiste en localStorage', async () => {

--- a/tests/unit/core/view-models/BookingViewModel.test.ts
+++ b/tests/unit/core/view-models/BookingViewModel.test.ts
@@ -51,6 +51,7 @@ describe('BookingViewModel', () => {
 
       vm.setTime('09:00');
       vm.setZone('gym');
+      vm.setClientId('client1');
     };
 
     it('delegates session consumption to ProgramModel after a successful booking', async () => {
@@ -110,6 +111,17 @@ describe('BookingViewModel', () => {
 
       expect(success).toBe(false);
       expect(mockProgramModel.consumeSessionForClient).not.toHaveBeenCalled();
+    });
+
+    it('returns false and sets error when clientId is not set', async () => {
+      await setupForBooking();
+      vm.setClientId(''); // simulate unauthenticated or missing UUID
+
+      const success = await vm.createBooking();
+
+      expect(success).toBe(false);
+      expect(vm.error).toBeTruthy();
+      expect(mockBookingModel.createBooking).not.toHaveBeenCalled();
     });
 
     it('delegates capacity check entirely to BookingModel — does not short-circuit based on local bookings cache', async () => {


### PR DESCRIPTION
Fixes #137

## Changes

- Remove hardcoded `clientId = 'client1'` from `BookingViewModel`
- `ViewModelProvider` now syncs the authenticated user's UUID to `BookingViewModel` via `useEffect` whenever auth state changes
- `ClientProgramView` uses `useAuthViewModel()` to get the real user ID instead of a hardcoded placeholder
- Unit test added to verify that `createBooking` returns false when `clientId` is missing

Generated with [Claude Code](https://claude.ai/code)