### PR TITLE
Fix Google sign-in getting stuck on /auth/callback

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -8,7 +8,11 @@ export function getSupabaseBrowserClient(): SupabaseClient | null {
   if (!url || !key) return null;
 
   if (!client) {
-    client = createClient(url, key);
+    // PKCE keeps the OAuth callback in `?code=` form (see auth/callback/page.tsx).
+    // Without it Supabase falls back to the implicit flow and returns tokens in
+    // the URL hash instead, which the callback page never handles, leaving
+    // Google sign-in stuck on the "Autenticando…" screen.
+    client = createClient(url, key, { auth: { flowType: 'pkce' } });
   }
   return client;
 }


### PR DESCRIPTION
## Summary
- Reported as "logout redirects to a stuck loading page at `/auth/callback#access_token=...`"
- Root cause: `src/lib/supabase.ts` created the Supabase client without pinning `flowType`, so `signInWithOAuth` used the default **implicit** flow and Google's redirect carried `access_token`/`refresh_token` in the URL **hash fragment**
- `src/app/auth/callback/page.tsx` only implements the **PKCE** path (`?code=` + `exchangeCodeForSession`), so it never recognized the hash-token redirect and the page was left stuck on the "Autenticando…" loading state instead of completing sign-in and routing to `/client` or `/trainer`
- Fix: explicitly set `flowType: 'pkce'` on the Supabase client so `signInWithOAuth` requests match the callback page's existing code-exchange logic
- Sign-out itself (`AuthViewModel.signOut()` → `AuthGuard` redirecting to `/login` once `currentUser` becomes `null`) was already correct; the stuck screen was purely the OAuth callback mismatch

## Test plan
- [x] `npm run test:run` — 388 tests passed
- [x] `npm run typecheck`
- [x] `npm run lint` (only pre-existing warnings)
- [x] `npm run build`


---
_Generated by [Claude Code](https://claude.ai/code/session_01FLzhH29DwkDfTcFGxDWq9A)_