### PR TITLE
Fix auth callback hanging forever on unhandled errors

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { getSupabaseBrowserClient } from '@/lib/supabase';
 
@@ -10,6 +10,9 @@ export default function AuthCallbackPage() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const [status, setStatus] = useState<Status>('loading');
+  // PKCE codes are single-use; guard against the effect re-running (e.g. a
+  // searchParams/router identity change) and exchanging the same code twice.
+  const hasRunRef = useRef(false);
 
   useEffect(() => {
     const code = searchParams.get('code');
@@ -18,43 +21,56 @@ export default function AuthCallbackPage() {
     const supabase = getSupabaseBrowserClient();
     if (!supabase) { router.replace('/login'); return; }
 
+    if (hasRunRef.current) return;
+    hasRunRef.current = true;
+
+    const fail = () => {
+      setStatus('error');
+      setTimeout(() => router.replace('/login'), 1500);
+    };
+
     (async () => {
-      // 1. Exchange the OAuth authorization code for an authenticated session.
-      //    The returned user object contains the email from the Google account.
-      const { data, error } = await supabase.auth.exchangeCodeForSession(code);
-      if (error || !data.user) {
-        setStatus('error');
-        setTimeout(() => router.replace('/login'), 1500);
-        return;
+      try {
+        // 1. Exchange the OAuth authorization code for an authenticated session.
+        //    The returned user object contains the email from the Google account.
+        const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+        if (error || !data.user) {
+          fail();
+          return;
+        }
+
+        const { id: userId, email } = data.user;
+
+        // 2. Determine role: check whether this email is registered as an active trainer.
+        //    The trainers table has public read, so no auth restriction applies here.
+        let role: 'trainer' | 'client' = 'client';
+        if (email) {
+          const { data: trainer } = await supabase
+            .from('trainers')
+            .select('id')
+            .eq('email', email)
+            .eq('is_active', true)
+            .maybeSingle();
+          if (trainer) role = 'trainer';
+        }
+
+        // 3. Persist the correct role. The DB trigger may have defaulted to 'client';
+        //    upserting on the primary key corrects it without overwriting full_name.
+        await supabase
+          .from('user_profiles')
+          .upsert({ id: userId, role, email: email ?? null }, { onConflict: 'id' });
+
+        // 4. Refresh the session so the global onAuthStateChange listener re-fires
+        //    and AuthViewModel picks up the now-correct role from user_profiles.
+        await supabase.auth.refreshSession();
+
+        // 5. Navigate to the dashboard that matches the resolved role.
+        router.replace(role === 'trainer' ? '/trainer' : '/client');
+      } catch {
+        // Any thrown error (e.g. network failure, missing PKCE code verifier)
+        // must still resolve the loading state instead of hanging forever.
+        fail();
       }
-
-      const { id: userId, email } = data.user;
-
-      // 2. Determine role: check whether this email is registered as an active trainer.
-      //    The trainers table has public read, so no auth restriction applies here.
-      let role: 'trainer' | 'client' = 'client';
-      if (email) {
-        const { data: trainer } = await supabase
-          .from('trainers')
-          .select('id')
-          .eq('email', email)
-          .eq('is_active', true)
-          .maybeSingle();
-        if (trainer) role = 'trainer';
-      }
-
-      // 3. Persist the correct role. The DB trigger may have defaulted to 'client';
-      //    upserting on the primary key corrects it without overwriting full_name.
-      await supabase
-        .from('user_profiles')
-        .upsert({ id: userId, role, email: email ?? null }, { onConflict: 'id' });
-
-      // 4. Refresh the session so the global onAuthStateChange listener re-fires
-      //    and AuthViewModel picks up the now-correct role from user_profiles.
-      await supabase.auth.refreshSession();
-
-      // 5. Navigate to the dashboard that matches the resolved role.
-      router.replace(role === 'trainer' ? '/trainer' : '/client');
     })();
   }, [searchParams, router]);
 


### PR DESCRIPTION
## Summary
- Follow-up to #145 (merged): after that fix, Google sign-in now correctly returns `?code=...` (PKCE) instead of implicit-flow hash tokens, but the `/auth/callback` page could still get stuck forever on the "Autenticando…" loading screen
- Root cause: the async flow in `src/app/auth/callback/page.tsx` had no `try/catch`. Only the first step (`exchangeCodeForSession`) checked its returned `error`; any exception thrown afterward — e.g. `exchangeCodeForSession` failing to find its PKCE code verifier in storage, a transient network error on the `trainers`/`user_profiles` queries, or `refreshSession` — left the promise rejected with no UI update, so the page never reached `setStatus('error')` or `router.replace(...)`
- Fix: wrap the whole exchange/role-resolution flow in `try/catch` so any failure surfaces the existing error state and redirects to `/login` instead of hanging indefinitely
- Also guards against the effect re-running and exchanging the same single-use PKCE `code` twice (a `useRef` flag), since a second exchange of an already-consumed code would otherwise fail silently

## Test plan
- [x] `npm run test:run` — 388 tests passed
- [x] `npm run typecheck`
- [x] `npm run lint` (only pre-existing warnings)
- [x] `npm run build`


---
_Generated by [Claude Code](https://claude.ai/code/session_01FLzhH29DwkDfTcFGxDWq9A)_