### PR TITLE
Fix trainer time slots showing wrong day's schedule in booking flow

### DIFF
--- a/src/components/BookingView.tsx
+++ b/src/components/BookingView.tsx
@@ -142,6 +142,7 @@ const BookingView = observer(() => {
           <TimeSelectionView
             selectedDate={vm.selectedDate}
             trainers={vm.trainers}
+            slotsByTrainer={vm.availableSlotsByTrainer}
             bookings={vm.bookings}
             selectedTrainerName={vm.selectedTrainerName}
             selectedTime={vm.selectedTime}
@@ -176,8 +177,8 @@ interface TimeSelectionViewProps {
   trainers: Array<{
     id: string;
     name: string;
-    availableSlots: string[];
   }>;
+  slotsByTrainer: Record<string, string[]>;
   bookings: Booking[];
   selectedTrainerName: string | null;
   selectedTime: string | null;
@@ -192,6 +193,7 @@ interface TimeSelectionViewProps {
 const TimeSelectionView: React.FC<TimeSelectionViewProps> = ({
   selectedDate,
   trainers,
+  slotsByTrainer,
   bookings,
   selectedTrainerName,
   selectedTime,
@@ -246,14 +248,19 @@ const TimeSelectionView: React.FC<TimeSelectionViewProps> = ({
       </div>
 
       <div className="space-y-6">
-        {trainers.map((trainer) => (
+        {trainers.map((trainer) => {
+          const trainerSlots = slotsByTrainer[trainer.id] ?? [];
+
+          if (trainerSlots.length === 0) return null;
+
+          return (
           <div key={trainer.id} className="border border-gray-200 rounded-lg p-4">
             <div className="mb-4">
               <h3 className="text-lg font-semibold text-gray-900">Entrenador {trainer.name}</h3>
             </div>
-            
+
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
-              {trainer.availableSlots.map((time: string) => {
+              {trainerSlots.map((time: string) => {
                 const isSelected = selectedTrainerName === `Entrenador ${trainer.name}` && selectedTime === time;
                 const gymCapacity = getZoneCapacity(trainer.id, time, 'gym');
                 const gabineteCapacity = getZoneCapacity(trainer.id, time, 'gabinete');
@@ -289,7 +296,8 @@ const TimeSelectionView: React.FC<TimeSelectionViewProps> = ({
               })}
             </div>
           </div>
-        ))}
+          );
+        })}
       </div>
 
       {/* Confirmation section */}

--- a/src/core/providers/ViewModelProvider.tsx
+++ b/src/core/providers/ViewModelProvider.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { createContext, useContext, useEffect, useMemo, ReactNode } from 'react';
+import { observer } from 'mobx-react-lite';
 import { BookingViewModel } from '../view-models/BookingViewModel';
 import { BookingModel } from '../models/BookingModel';
 import { ProgramViewModel } from '../view-models/ProgramViewModel';
@@ -25,7 +26,7 @@ interface ViewModelProviderProps {
   children: ReactNode;
 }
 
-export function ViewModelProvider({ children }: ViewModelProviderProps) {
+export const ViewModelProvider = observer(function ViewModelProvider({ children }: ViewModelProviderProps) {
   const service = useDataService();
   const authVM = useAuthViewModel();
 
@@ -56,7 +57,7 @@ export function ViewModelProvider({ children }: ViewModelProviderProps) {
       {children}
     </ViewModelContext.Provider>
   );
-}
+});
 
 export function useViewModels(): ViewModelContextType {
   const context = useContext(ViewModelContext);

--- a/src/core/services/SupabaseDataService.ts
+++ b/src/core/services/SupabaseDataService.ts
@@ -295,10 +295,14 @@ export class SupabaseProgramRepository implements IProgramRepository {
   }
 
   async getByClient(clientId: string): Promise<Program[]> {
+    // client_ids is jsonb, not a native Postgres array — supabase-js's .contains()
+    // serializes a JS array as Postgres array-literal syntax (cs.{val}), which
+    // PostgREST rejects as invalid JSON for a jsonb column. Pre-serializing to a
+    // JSON string routes through the string branch instead, producing cs.["val"].
     const { data, error } = await this.client
       .from('programs')
       .select('*')
-      .contains('client_ids', [clientId]);
+      .contains('client_ids', JSON.stringify([clientId]));
     if (error) throw new Error(error.message);
     return (data as ProgramRow[]).map(ProgramMapper.toDomain);
   }

--- a/src/core/view-models/BookingViewModel.ts
+++ b/src/core/view-models/BookingViewModel.ts
@@ -19,6 +19,7 @@ export class BookingViewModel {
   // Estado observable
   trainers: Trainer[] = [];
   availableSlots: string[] = [];
+  availableSlotsByTrainer: Record<string, string[]> = {};
   bookings: Booking[] = [];
   isLoading = false;
   error: string | null = null;
@@ -86,6 +87,34 @@ export class BookingViewModel {
     } finally {
       this.setLoading(false);
     }
+  }
+
+  // Carga los horarios disponibles de todos los entrenadores para la fecha seleccionada,
+  // ya que el cliente elige entrenador y horario en un mismo paso (ver TimeSelectionView).
+  async loadAvailableSlotsForDate(date: Date) {
+    this.setLoading(true);
+    try {
+      const entries = await Promise.all(
+        this.trainers.map(async (trainer) => {
+          const slots = await this.model.getAvailableSlots(trainer.id, date);
+          return [trainer.id, slots] as const;
+        })
+      );
+      runInAction(() => {
+        this.availableSlotsByTrainer = Object.fromEntries(entries);
+        this.error = null;
+      });
+    } catch (err) {
+      runInAction(() => {
+        this.error = err instanceof Error ? err.message : 'Error cargando disponibilidad';
+      });
+    } finally {
+      this.setLoading(false);
+    }
+  }
+
+  getSlotsForTrainer(trainerId: string): string[] {
+    return this.availableSlotsByTrainer[trainerId] ?? [];
   }
 
   async createBooking(): Promise<boolean> {
@@ -226,7 +255,8 @@ export class BookingViewModel {
     this.selectedDate = date;
     this.selectedTime = null; // Reset time when date changes
     this.clearCapacityCache(); // Limpiar cache al cambiar fecha
-    
+    this.loadAvailableSlotsForDate(date);
+
     if (this.selectedTrainer) {
       this.loadAvailableSlots(this.selectedTrainer.id, date);
     }
@@ -261,6 +291,7 @@ export class BookingViewModel {
     this.selectedTime = null;
     this.selectedZone = null;
     this.availableSlots = [];
+    this.availableSlotsByTrainer = {};
     this.clearCapacityCache();
   }
 

--- a/tests/unit/core/services/SupabaseDataService.test.ts
+++ b/tests/unit/core/services/SupabaseDataService.test.ts
@@ -538,14 +538,14 @@ describe('SupabaseProgramRepository', () => {
   });
 
   describe('getByClient', () => {
-    it('uses .contains() with the clientId in an array', async () => {
+    it('uses .contains() with a JSON-stringified array, since client_ids is jsonb', async () => {
       const builder = makeBuilder({ data: [programRow], error: null });
       const client = makeClient(builder);
       const repo = new SupabaseProgramRepository(client);
 
       await repo.getByClient('c1');
 
-      expect(builder.contains).toHaveBeenCalledWith('client_ids', ['c1']);
+      expect(builder.contains).toHaveBeenCalledWith('client_ids', JSON.stringify(['c1']));
     });
   });
 


### PR DESCRIPTION
## Summary

- `TimeSelectionView` in `BookingView.tsx` was rendering `trainer.availableSlots`, which `SupabaseTrainerRepository.getAll()` always populates from `trainer_schedules` filtered to **today's date**, regardless of which date the client selects on the calendar.
- `BookingViewModel.loadAvailableSlots()` already fetched the correct per-date slots via `BookingModel.getAvailableSlots(trainerId, date)`, but the result (`vm.availableSlots`) was never rendered, and it only worked for a single already-selected trainer — while the UI needs every trainer's slots for the chosen date before a trainer is picked.
- Added `BookingViewModel.loadAvailableSlotsForDate(date)`, which fetches `BookingModel.getAvailableSlots` for every loaded trainer and stores the result in a new `availableSlotsByTrainer` map, triggered from `setDate()`.
- Updated `TimeSelectionView` to render from `slotsByTrainer[trainer.id]` instead of the static `trainer.availableSlots`, and to skip rendering a trainer block when they have no slots for the selected date.

### Follow-up fix 1: "Confirmar Reserva" stayed disabled

While manually testing the flow end-to-end, found that the confirm button never enabled even with date/trainer/time/zone all selected. Root cause: `ViewModelProvider` syncs the authenticated user's id into `bookingVM.clientId` via a `useEffect` keyed on `authVM.currentUser` (a MobX observable), but the component was never wrapped in `observer()`. Reading an observable outside `observer()` doesn't subscribe the component to its changes, so the effect only ran once at the initial (pre-login) render — `clientId` stayed `''` forever, and `canCreateBooking` (which requires a non-empty `clientId`) was permanently false. Wrapped `ViewModelProvider` in `mobx-react-lite`'s `observer()` so it re-renders (and re-runs the effect) once auth resolves. Verified fixed with a Playwright smoke test driving the real dev server end-to-end (login → date → trainer/time → zone → confirm → success modal).

### Follow-up fix 2: "Mi Programa" info never loads against real Supabase

A HAR capture from a deployed preview showed every `programs` request for a real client UUID returning `400 invalid input syntax for type json` ("Token \"cccccccc\" is invalid"). `client_ids` is a `jsonb` column, not a native Postgres array, but `SupabaseDataService.getByClient()` called `.contains('client_ids', [clientId])`. supabase-js's `.contains()` serializes a plain JS array using Postgres array-literal syntax (`cs.{val}`), which is only valid for array-typed columns — PostgREST rejects that as invalid JSON for `jsonb`. This broke the "Mi Programa" pending-sessions banner in the booking flow and silently broke session consumption after a booking. Fixed by pre-serializing with `JSON.stringify()`, which routes through `.contains()`'s string branch and produces the JSON-array syntax (`cs.["val"]`) the column actually needs. Updated the existing unit test, which had encoded the buggy call shape.

## Test plan

- [x] `npm run test:run` — all 388 tests pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (pre-existing warnings only)
- [x] `npm run build` — succeeds
- [x] Manual Playwright smoke test of the full booking flow against the local dev server (confirmed slots render per-date and the booking completes)
- [x] Root-caused the `programs` 400 via a HAR capture from a real deployment

Fixes #151

https://claude.ai/code/session_01X88LBtKS25dbQXkw9TesNJ
