### PR TITLE
Fix supabase-js onAuthStateChange deadlock hanging fetchRole

### DIFF
--- a/src/core/services/SupabaseAuthService.ts
+++ b/src/core/services/SupabaseAuthService.ts
@@ -49,15 +49,26 @@ async getCurrentUser(): Promise<AuthUser | null> {
 
 onAuthStateChange(callback: (user: AuthUser | null) => void): () => void {
   const { data: { subscription } } = this.client.auth.onAuthStateChange(
-    async (_event, session) => {
+    (_event, session) => {
       console.log(`[Auth] onAuthStateChange event: ${_event}, hasSession=${!!session}`);
       if (!session?.user) {
         callback(null);
         return;
       }
       const { id, email } = session.user;
-      const role = await this.fetchRole(id, email ?? undefined);
-      callback({ id, email: email!, role });
+      // Defer the role lookup instead of awaiting it here: calling any other
+      // Supabase method synchronously inside this callback deadlocks the
+      // client's internal auth lock (see supabase/auth-js#762) - the fetch
+      // itself completes, but its promise never settles because it's
+      // waiting on a lock still held by this very callback.
+      setTimeout(() => {
+        this.fetchRole(id, email ?? undefined)
+          .then((role) => callback({ id, email: email!, role }))
+          .catch((err) => {
+            console.error('[Auth] onAuthStateChange: fetchRole failed', err);
+            callback(null);
+          });
+      }, 0);
     },
     );
   return () => subscription.unsubscribe();

--- a/tests/unit/core/services/SupabaseAuthService.test.ts
+++ b/tests/unit/core/services/SupabaseAuthService.test.ts
@@ -333,14 +333,14 @@ describe('SupabaseAuthService', () => {
 
     it('calls callback with AuthUser when session is present', async () => {
       const callback = vi.fn();
-      let capturedHandler: ((event: string, session: object) => Promise<void>) | null = null;
+      let capturedHandler: ((event: string, session: object) => void) | null = null;
 
       const profileBuilder = makeQueryBuilder({ role: 'trainer' });
       const trainerBuilder = makeQueryBuilder(null);
       client = {
         auth: {
           onAuthStateChange: vi.fn().mockImplementation(
-            (handler: (event: string, session: object) => Promise<void>) => {
+            (handler: (event: string, session: object) => void) => {
               capturedHandler = handler;
               return { data: { subscription: { unsubscribe: vi.fn() } } };
             },
@@ -360,15 +360,44 @@ describe('SupabaseAuthService', () => {
       service = new SupabaseAuthService(client);
 
       service.onAuthStateChange(callback);
-      await capturedHandler!('SIGNED_IN', {
+      capturedHandler!('SIGNED_IN', {
         user: { id: 'u1', email: 'test@nivel.gym' },
       });
+      await vi.waitFor(() => expect(callback).toHaveBeenCalled());
 
       expect(callback).toHaveBeenCalledWith({
         id: 'u1',
         email: 'test@nivel.gym',
         role: 'trainer',
       });
+    });
+
+    it('does not call fetchRole synchronously within the auth callback (avoids the supabase-js lock deadlock)', () => {
+      const callback = vi.fn();
+      let capturedHandler: ((event: string, session: object) => void) | null = null;
+
+      const profileBuilder = makeQueryBuilder({ role: 'trainer' });
+      client = {
+        auth: {
+          onAuthStateChange: vi.fn().mockImplementation(
+            (handler: (event: string, session: object) => void) => {
+              capturedHandler = handler;
+              return { data: { subscription: { unsubscribe: vi.fn() } } };
+            },
+          ),
+          signInWithPassword: vi.fn(),
+          signOut: vi.fn(),
+          getUser: vi.fn(),
+          signInWithOAuth: vi.fn(),
+        },
+        from: vi.fn().mockReturnValue(profileBuilder),
+      } as unknown as ReturnType<typeof makeAuthClient>;
+      service = new SupabaseAuthService(client);
+
+      service.onAuthStateChange(callback);
+      capturedHandler!('SIGNED_IN', { user: { id: 'u1', email: 'test@nivel.gym' } });
+
+      expect(client.from).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

Stacked on #160 — this is root cause 2 of #159; #160 covers root cause 1 (the unbounded "Cargando..." loading state).

**This PR is scoped to the deadlock fix only** — no timeout mechanism. Earlier iterations of this PR added a `withTimeout` guard around `fetchRole()`'s Supabase queries, but that timeout wasn't what fixed the bug: a HAR capture against a live Vercel preview showed the actual `user_profiles` request completing in under 600ms with a 200 response and the correct role — yet the client still hit the timeout every time, immediately followed by another `SIGNED_IN` event, looping indefinitely. The timeout was racing against a promise that was *deadlocked*, not slow, so it always lost; it just converted a silent infinite hang into a 10-second retry loop without fixing anything.

**Root cause:** calling any Supabase method synchronously inside the `onAuthStateChange` callback deadlocks the client's internal auth lock — a known `supabase-js` bug ([auth-js#762](https://github.com/supabase/auth-js/issues/762)). The wrapping promise never settles even though the HTTP request itself completes, because it's waiting on a lock still held by the very callback that's awaiting it.

**Fix:** `fetchRole()` is no longer awaited inline inside the `onAuthStateChange` callback. It's deferred via `setTimeout(0)` so it runs after the callback returns and releases the lock.

**Known residual risk (intentionally out of scope here):** `SupabaseAuthService.signIn()` (password login) calls `fetchRole()` directly, outside of `onAuthStateChange`, with no timeout protection anywhere in the stack. A genuinely slow/hung `user_profiles` query during password sign-in (unrelated to this deadlock) could still hang the login button forever. That's a separate, narrower concern from the reported deadlock and can be addressed independently if desired.

## Test plan

- [x] Added a regression test asserting `fetchRole` is never called synchronously inside the `onAuthStateChange` callback
- [x] Updated the existing "calls callback with AuthUser when session is present" test for the new deferred timing
- [x] `npm run test:run` — 402 tests pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (only pre-existing warnings unrelated to this change)
- [x] `npm run build` — succeeds
- [x] Verified against a live Vercel preview deployment (HAR + console log capture) that sign-in no longer hangs or loops

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gsg62PmzBtWHkJjxvmUgps)_
