### PR TITLE
Fix app stuck on Cargando/login due to auth timeouts and a supabase-js deadlock (#159)

### DIFF
--- a/src/core/providers/DataProvider.tsx
+++ b/src/core/providers/DataProvider.tsx
@@ -6,6 +6,11 @@ import { LocalStorageDataService } from '../repositories/localStorage';
 import { SupabaseDataService } from '../services/SupabaseDataService';
 import { getSupabaseBrowserClient } from '@/lib/supabase';
 import { isProductionEnvironment } from '@/lib/env';
+import { withTimeout } from '../utils/withTimeout';
+
+// Bounds how long we wait for service.initialize() before giving up, so a
+// hung network request can't leave the app stuck on the loading screen.
+const INITIALIZE_TIMEOUT_MS = 10_000;
 
 // Internal context — only for use by ViewModelProvider to access the service layer
 const DataServiceContext = createContext<IDataService | null>(null);
@@ -36,11 +41,14 @@ type ServiceSelection =
 function selectDataService(): ServiceSelection {
   const supabase = getSupabaseBrowserClient();
   if (supabase) {
+    console.log('[DataProvider] selected service: Supabase');
     return { service: new SupabaseDataService(supabase), isLocalStorageFallback: false };
   }
   if (isProductionEnvironment()) {
+    console.error('[DataProvider] selected service: none (production with no Supabase env vars configured)');
     return { service: null, isLocalStorageFallback: false };
   }
+  console.log('[DataProvider] selected service: LocalStorage fallback');
   return { service: new LocalStorageDataService(), isLocalStorageFallback: true };
 }
 
@@ -50,7 +58,16 @@ export function DataProvider({ children }: DataProviderProps) {
 
   useEffect(() => {
     if (!service) return;
-    service.initialize().then(() => setIsReady(true));
+const initStart = Date.now();
+    console.log('[DataProvider] initialize: start');
+    withTimeout(service.initialize(), INITIALIZE_TIMEOUT_MS, 'Timed out initializing data service')
+      .then(() => {
+        console.log(`[DataProvider] initialize: success (${Date.now() - initStart}ms)`);
+      })
+      .catch((err) => {
+        console.error(`[DataProvider] initialize: FAILED after ${Date.now() - initStart}ms`, err);
+      })
+      .finally(() => setIsReady(true));
   }, [service]);
 
   if (!service) {

--- a/src/core/services/SupabaseAuthService.ts
+++ b/src/core/services/SupabaseAuthService.ts
@@ -1,81 +1,121 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { AuthUser, UserRole } from '../types';
 import { IAuthService } from '../repositories/auth';
+import { withTimeout } from '../utils/withTimeout';
+
+// Bounds how long we wait for a role lookup before giving up, so a hung
+// user_profiles/trainers query can't leave signIn()/onAuthStateChange
+// hanging forever (see issue #159).
+const FETCH_ROLE_TIMEOUT_MS = 10_000;
 
 export class SupabaseAuthService implements IAuthService {
   constructor(private readonly client: SupabaseClient) {}
 
-  async signIn(email: string, password: string): Promise<AuthUser> {
-    const { data, error } = await this.client.auth.signInWithPassword({ email, password });
-    if (error) throw new Error(error.message);
+async signIn(email: string, password: string): Promise<AuthUser> {
+  const { data, error } = await this.client.auth.signInWithPassword({ email, password });
+  if (error) throw new Error(error.message);
 
-    const role = await this.fetchRole(data.user.id, data.user.email ?? undefined);
-    return { id: data.user.id, email: data.user.email!, role };
-  }
+  const role = await this.fetchRole(data.user.id, data.user.email ?? undefined);
+  return { id: data.user.id, email: data.user.email!, role };
+}
 
-  async signInWithGoogle(): Promise<void> {
-    const redirectTo = `${window.location.origin}/auth/callback`;
-    const { error } = await this.client.auth.signInWithOAuth({
-      provider: 'google',
-      options: { redirectTo },
-    });
-    if (error) throw new Error(error.message);
-  }
+async signInWithGoogle(): Promise<void> {
+  const redirectTo = `${window.location.origin}/auth/callback`;
+  const { error } = await this.client.auth.signInWithOAuth({
+    provider: 'google',
+    options: { redirectTo },
+  });
+  if (error) throw new Error(error.message);
+}
 
-  async signOut(): Promise<void> {
-    const { error } = await this.client.auth.signOut();
-    if (error) throw new Error(error.message);
-  }
+async signOut(): Promise<void> {
+  const { error } = await this.client.auth.signOut();
+  if (error) throw new Error(error.message);
+}
 
-  async getCurrentUser(): Promise<AuthUser | null> {
+async getCurrentUser(): Promise<AuthUser | null> {
+  const start = Date.now();
+  console.log('[Auth] getCurrentUser: start');
+  try {
     const { data: { user } } = await this.client.auth.getUser();
-    if (!user) return null;
+    console.log(`[Auth] getUser() resolved in ${Date.now() - start}ms, user=${user ? user.id : 'null'}`);
+    if (!user) {
+      console.log(`[Auth] getCurrentUser: done (${Date.now() - start}ms total), no user`);
+      return null;
+    }
 
-    const role = await this.fetchRole(user.id, user.email ?? undefined);
+  const role = await this.fetchRole(user.id, user.email ?? undefined);
+    console.log(`[Auth] getCurrentUser: done (${Date.now() - start}ms total), role=${role}`);
     return { id: user.id, email: user.email!, role };
+  } catch (err) {
+    console.error(`[Auth] getCurrentUser: FAILED after ${Date.now() - start}ms`, err);
+    throw err;
   }
+}
 
-  onAuthStateChange(callback: (user: AuthUser | null) => void): () => void {
-    const { data: { subscription } } = this.client.auth.onAuthStateChange(
-      async (_event, session) => {
-        if (!session?.user) {
-          callback(null);
-          return;
-        }
-        const { id, email } = session.user;
-        const role = await this.fetchRole(id, email ?? undefined);
-        callback({ id, email: email!, role });
-      },
+onAuthStateChange(callback: (user: AuthUser | null) => void): () => void {
+  const { data: { subscription } } = this.client.auth.onAuthStateChange(
+    (_event, session) => {
+      console.log(`[Auth] onAuthStateChange event: ${_event}, hasSession=${!!session}`);
+      if (!session?.user) {
+        callback(null);
+        return;
+      }
+      const { id, email } = session.user;
+      // Defer the role lookup instead of awaiting it here: calling any other
+      // Supabase method synchronously inside this callback deadlocks the
+      // client's internal auth lock (see supabase/auth-js#762) - the fetch
+      // itself completes, but its promise never settles because it's
+      // waiting on a lock still held by this very callback.
+      setTimeout(() => {
+        this.fetchRole(id, email ?? undefined)
+          .then((role) => callback({ id, email: email!, role }))
+          .catch((err) => {
+            console.error('[Auth] onAuthStateChange: fetchRole failed', err);
+            callback(null);
+          });
+      }, 0);
+    },
     );
-    return () => subscription.unsubscribe();
+  return () => subscription.unsubscribe();
+}
+
+// Looks up the user's role. When no profile exists (first-time OAuth sign-in),
+// checks the trainers table by email so trainers are recognised correctly.
+private async fetchRole(userId: string, email?: string): Promise<UserRole> {
+  const start = Date.now();
+  console.log(`[Auth] fetchRole: start for user ${userId}`);
+  const { data } = await withTimeout(
+    this.client.from('user_profiles').select('role').eq('id', userId).single(),
+    FETCH_ROLE_TIMEOUT_MS,
+    'Timed out fetching user role',
+  );
+
+  if (data) {
+    console.log(`[Auth] fetchRole: found profile in ${Date.now() - start}ms, role=${(data as { role: UserRole }).role}`);
+    return (data as { role: UserRole }).role;
   }
 
-  // Looks up the user's role. When no profile exists (first-time OAuth sign-in),
-  // checks the trainers table by email so trainers are recognised correctly.
-  private async fetchRole(userId: string, email?: string): Promise<UserRole> {
-    const { data } = await this.client
-      .from('user_profiles')
-      .select('role')
-      .eq('id', userId)
-      .single();
+  // No profile yet — the DB trigger may not have fired or this is a new OAuth identity.
+  // Determine role by checking whether this email belongs to an active trainer.
+  console.log(`[Auth] fetchRole: no profile found after ${Date.now() - start}ms, checking trainers table`);
+  const role = await this.resolveRoleByEmail(email);
+  await withTimeout(
+    this.client.from('user_profiles').insert({ id: userId, role, email: email ?? null }),
+    FETCH_ROLE_TIMEOUT_MS,
+    'Timed out creating user profile',
+  );
+  console.log(`[Auth] fetchRole: resolved role=${role} in ${Date.now() - start}ms total`);
+  return role;
+}
 
-    if (data) return (data as { role: UserRole }).role;
-
-    // No profile yet — the DB trigger may not have fired or this is a new OAuth identity.
-    // Determine role by checking whether this email belongs to an active trainer.
-    const role = await this.resolveRoleByEmail(email);
-    await this.client.from('user_profiles').insert({ id: userId, role, email: email ?? null });
-    return role;
-  }
-
-  private async resolveRoleByEmail(email?: string): Promise<UserRole> {
-    if (!email) return 'client';
-    const { data } = await this.client
-      .from('trainers')
-      .select('id')
-      .eq('email', email)
-      .eq('is_active', true)
-      .maybeSingle();
-    return data ? 'trainer' : 'client';
-  }
+private async resolveRoleByEmail(email?: string): Promise<UserRole> {
+  if (!email) return 'client';
+  const { data } = await withTimeout(
+    this.client.from('trainers').select('id').eq('email', email).eq('is_active', true).maybeSingle(),
+    FETCH_ROLE_TIMEOUT_MS,
+    'Timed out resolving role by email',
+  );
+  return data ? 'trainer' : 'client';
+}
 }

--- a/src/core/utils/withTimeout.ts
+++ b/src/core/utils/withTimeout.ts
@@ -1,0 +1,26 @@
+/**
+ * Races a promise against a timeout so callers always settle within a
+ * bounded time. Without this, a hung network request (e.g. a Supabase
+ * backend that never responds) leaves the original promise pending
+ * forever, and any .then()/.catch()/.finally() attached to it never runs -
+ * which is what caused the app to get stuck on "Cargando..." indefinitely
+ * (see issue #159).
+ */
+export function withTimeout<T>(promise: PromiseLike<T>, ms: number, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      console.warn(`[withTimeout] "${message}" timed out after ${ms}ms`);
+      reject(new Error(message));
+    }, ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}

--- a/src/core/view-models/AuthViewModel.ts
+++ b/src/core/view-models/AuthViewModel.ts
@@ -1,6 +1,11 @@
 import { makeAutoObservable, runInAction } from 'mobx';
 import { AuthUser } from '../types';
 import { AuthModel } from '../models/AuthModel';
+import { withTimeout } from '../utils/withTimeout';
+
+// Bounds how long we wait for the initial session check before giving up,
+// so a hung network request can't leave the app stuck loading.
+const GET_CURRENT_USER_TIMEOUT_MS = 10_000;
 
 export class AuthViewModel {
   currentUser: AuthUser | null = null;
@@ -14,19 +19,34 @@ export class AuthViewModel {
   }
 
   initialize(): void {
+    console.log('[AuthViewModel] initialize() called');
     this.unsubscribe = this.authModel.onAuthStateChange((user) => {
+      console.log(`[AuthViewModel] onAuthStateChange fired, user=${user ? user.id : 'null'}`);
       runInAction(() => {
         this.currentUser = user;
         this.isLoading = false;
       });
     });
 
-    this.authModel.getCurrentUser().then((user) => {
-      runInAction(() => {
-        this.currentUser = user;
-        this.isLoading = false;
+    withTimeout(
+      this.authModel.getCurrentUser(),
+      GET_CURRENT_USER_TIMEOUT_MS,
+      'Timed out checking session',
+    )
+      .then((user) => {
+        console.log(`[AuthViewModel] getCurrentUser resolved, user=${user ? user.id : 'null'}`);
+        runInAction(() => {
+          this.currentUser = user;
+          this.isLoading = false;
+        });
+      })
+      .catch((err) => {
+        console.error('[AuthViewModel] getCurrentUser timed out or errored:', err);
+        runInAction(() => {
+          this.error = err instanceof Error ? err.message : 'Error al verificar la sesión';
+          this.isLoading = false;
+        });
       });
-    });
   }
 
   dispose(): void {

--- a/tests/unit/core/providers/DataProvider.test.tsx
+++ b/tests/unit/core/providers/DataProvider.test.tsx
@@ -100,6 +100,21 @@ describe('DataProvider — service selection', () => {
     await waitFor(() => expect(screen.getByTestId('child')).toBeInTheDocument());
   });
 
+  it('renders children even when service.initialize() rejects', async () => {
+    vi.mocked(getSupabaseBrowserClient).mockReturnValue(null);
+    mockInitialize.mockRejectedValueOnce(new Error('init failed'));
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <DataProvider>
+        <div data-testid="child" />
+      </DataProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('child')).toBeInTheDocument());
+    consoleErrorSpy.mockRestore();
+  });
+
   it('shows a loading indicator while initializing', () => {
     vi.mocked(getSupabaseBrowserClient).mockReturnValue(null);
     // initialize never resolves within this synchronous check

--- a/tests/unit/core/services/SupabaseAuthService.test.ts
+++ b/tests/unit/core/services/SupabaseAuthService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { SupabaseAuthService } from '@/core/services/SupabaseAuthService';
 
@@ -333,14 +333,14 @@ describe('SupabaseAuthService', () => {
 
     it('calls callback with AuthUser when session is present', async () => {
       const callback = vi.fn();
-      let capturedHandler: ((event: string, session: object) => Promise<void>) | null = null;
+      let capturedHandler: ((event: string, session: object) => void) | null = null;
 
       const profileBuilder = makeQueryBuilder({ role: 'trainer' });
       const trainerBuilder = makeQueryBuilder(null);
       client = {
         auth: {
           onAuthStateChange: vi.fn().mockImplementation(
-            (handler: (event: string, session: object) => Promise<void>) => {
+            (handler: (event: string, session: object) => void) => {
               capturedHandler = handler;
               return { data: { subscription: { unsubscribe: vi.fn() } } };
             },
@@ -360,15 +360,114 @@ describe('SupabaseAuthService', () => {
       service = new SupabaseAuthService(client);
 
       service.onAuthStateChange(callback);
-      await capturedHandler!('SIGNED_IN', {
+      capturedHandler!('SIGNED_IN', {
         user: { id: 'u1', email: 'test@nivel.gym' },
       });
+      await vi.waitFor(() => expect(callback).toHaveBeenCalled());
 
       expect(callback).toHaveBeenCalledWith({
         id: 'u1',
         email: 'test@nivel.gym',
         role: 'trainer',
       });
+    });
+
+    it('does not call fetchRole synchronously within the auth callback (avoids the supabase-js lock deadlock)', () => {
+      const callback = vi.fn();
+      let capturedHandler: ((event: string, session: object) => void) | null = null;
+
+      const profileBuilder = makeQueryBuilder({ role: 'trainer' });
+      client = {
+        auth: {
+          onAuthStateChange: vi.fn().mockImplementation(
+            (handler: (event: string, session: object) => void) => {
+              capturedHandler = handler;
+              return { data: { subscription: { unsubscribe: vi.fn() } } };
+            },
+          ),
+          signInWithPassword: vi.fn(),
+          signOut: vi.fn(),
+          getUser: vi.fn(),
+          signInWithOAuth: vi.fn(),
+        },
+        from: vi.fn().mockReturnValue(profileBuilder),
+      } as unknown as ReturnType<typeof makeAuthClient>;
+      service = new SupabaseAuthService(client);
+
+      service.onAuthStateChange(callback);
+      capturedHandler!('SIGNED_IN', { user: { id: 'u1', email: 'test@nivel.gym' } });
+
+      expect(client.from).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // fetchRole — timeout handling (issue #159)
+  // -------------------------------------------------------------------------
+
+  describe('fetchRole — timeout handling', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    function makeHungClient() {
+      const hungProfileBuilder = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockReturnValue(new Promise(() => {})),
+        maybeSingle: vi.fn().mockReturnValue(new Promise(() => {})),
+        insert: vi.fn().mockResolvedValue({ error: null }),
+      };
+      const unsubscribeFn = vi.fn();
+      let capturedHandler: ((event: string, session: object) => void) | null = null;
+
+      const client = {
+        auth: {
+          signInWithPassword: vi.fn().mockResolvedValue({
+            data: { user: { id: 'u1', email: 'test@nivel.gym' } },
+            error: null,
+          }),
+          signOut: vi.fn(),
+          getUser: vi.fn(),
+          signInWithOAuth: vi.fn(),
+          onAuthStateChange: vi.fn().mockImplementation(
+            (handler: (event: string, session: object) => void) => {
+              capturedHandler = handler;
+              return { data: { subscription: { unsubscribe: unsubscribeFn } } };
+            },
+          ),
+        },
+        from: vi.fn().mockReturnValue(hungProfileBuilder),
+        _getCapturedHandler: () => capturedHandler,
+      };
+
+      return client as unknown as SupabaseClient & { _getCapturedHandler: () => typeof capturedHandler };
+    }
+
+    it('rejects signIn() with a timeout error when the user_profiles lookup never resolves', async () => {
+      vi.useFakeTimers();
+      const hungClient = makeHungClient();
+      const hungService = new SupabaseAuthService(hungClient);
+
+      const promise = hungService.signIn('test@nivel.gym', 'secret');
+      const assertion = expect(promise).rejects.toThrow('Timed out fetching user role');
+      await vi.advanceTimersByTimeAsync(10_000);
+      await assertion;
+    });
+
+    it('calls onAuthStateChange callback with null when the role lookup times out', async () => {
+      vi.useFakeTimers();
+      const hungClient = makeHungClient();
+      const hungService = new SupabaseAuthService(hungClient);
+      const callback = vi.fn();
+
+      hungService.onAuthStateChange(callback);
+      hungClient._getCapturedHandler()!('SIGNED_IN', {
+        user: { id: 'u1', email: 'test@nivel.gym' },
+      });
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(callback).toHaveBeenCalledWith(null);
     });
   });
 });

--- a/tests/unit/core/utils/withTimeout.test.ts
+++ b/tests/unit/core/utils/withTimeout.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { withTimeout } from '@/core/utils/withTimeout';
+
+describe('withTimeout', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves with the original value when the promise settles before the timeout', async () => {
+    const result = await withTimeout(Promise.resolve('done'), 1000, 'timed out');
+    expect(result).toBe('done');
+  });
+
+  it('rejects with the original error when the promise rejects before the timeout', async () => {
+    await expect(
+      withTimeout(Promise.reject(new Error('boom')), 1000, 'timed out'),
+    ).rejects.toThrow('boom');
+  });
+
+  it('rejects with the timeout message when the promise never settles', async () => {
+    vi.useFakeTimers();
+    const hung = new Promise(() => {});
+
+    const result = withTimeout(hung, 1000, 'timed out');
+    const assertion = expect(result).rejects.toThrow('timed out');
+    await vi.advanceTimersByTimeAsync(1000);
+    await assertion;
+  });
+
+  it('clears the timer once the promise settles, so it does not fire later', async () => {
+    vi.useFakeTimers();
+    const clearSpy = vi.spyOn(global, 'clearTimeout');
+
+    await withTimeout(Promise.resolve('done'), 1000, 'timed out');
+
+    expect(clearSpy).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/core/view-models/AuthViewModel.test.ts
+++ b/tests/unit/core/view-models/AuthViewModel.test.ts
@@ -80,6 +80,16 @@ describe('AuthViewModel', () => {
       expect(vm.currentUser).toBeNull();
     });
 
+    it('sets isLoading to false and records an error when getCurrentUser rejects', async () => {
+      vi.mocked(authModel.getCurrentUser).mockRejectedValue(new Error('Network error'));
+
+      vm.initialize();
+      await vi.waitFor(() => expect(vm.isLoading).toBe(false));
+
+      expect(vm.error).toBe('Network error');
+      expect(vm.currentUser).toBeNull();
+    });
+
     it('updates currentUser when onAuthStateChange fires', async () => {
       const user = makeUser();
       vi.mocked(authModel.getCurrentUser).mockResolvedValue(null);


### PR DESCRIPTION
## Summary

Fixes #159. Consolidates the previously-stacked #160 and #161 into a single, mergeable PR against `main`. Verified working against a live Vercel preview deployment.

**The bug had two layers:**

1. **Unbounded loading state.** `DataProvider.tsx` called `service.initialize().then(() => setIsReady(true))` with no error handler, and `AuthViewModel.initialize()` had the same gap around `getCurrentUser()`. A rejected promise left the app stuck on the "Cargando..." spinner forever, with no subsequent network activity — matching the originally reported symptom.
2. **A `fetchRole()` timeout that masked a deeper deadlock.** After adding a `withTimeout` guard around `fetchRole()` (called from `signIn()`, `getCurrentUser()`, and the `onAuthStateChange` listener), a live console/HAR capture showed the `user_profiles` request completing in under 600ms with a 200 response and the correct role — yet the client still hit the 10s timeout every time, immediately followed by another `SIGNED_IN` event, looping indefinitely. This matches a known `supabase-js` bug ([auth-js#762](https://github.com/supabase/auth-js/issues/762)): calling any other Supabase method synchronously inside the `onAuthStateChange` callback deadlocks the client's internal auth lock, so the wrapping promise never settles even though the HTTP request itself completes.

**The fix:**

- Added a `withTimeout` utility, wired into `DataProvider.initialize()` and `AuthViewModel.getCurrentUser()`, so a genuinely hung request can no longer strand the UI.
- Wrapped `fetchRole()`'s Supabase queries with the same timeout as a safety net for slow/hung requests reached via `signIn()` or `getCurrentUser()` (which don't run inside the `onAuthStateChange` callback and aren't affected by the deadlock).
- Deferred the `fetchRole()` call in the `onAuthStateChange` listener via `setTimeout(..., 0)` instead of awaiting it inline, so the callback releases the internal auth lock before any other Supabase call is made — this is the actual fix for the deadlock/loop.
- Added diagnostic logging throughout the auth flow to make this class of issue easier to diagnose from browser console output in the future.

This supersedes #160 and #161, which are being closed in favor of this consolidated PR.

## Test plan

- [x] `npm run test:run` — 404 tests pass, including new coverage for the `withTimeout` guards and a regression test asserting `fetchRole` is never called synchronously inside the `onAuthStateChange` callback
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (only pre-existing warnings unrelated to this change)
- [x] `npm run build` — succeeds
- [x] Verified against a live Vercel preview deployment (HAR + console log capture) that sign-in no longer hangs or loops


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gsg62PmzBtWHkJjxvmUgps)_