### PR TITLE
Fix silent loading/error states in trainer's client picker

### DIFF
--- a/src/components/trainer/CreateProgramForm.tsx
+++ b/src/components/trainer/CreateProgramForm.tsx
@@ -190,24 +190,35 @@ const CreateProgramForm = observer(function CreateProgramForm() {
         <label className="block text-sm font-medium text-gray-700 mb-2">
           Cliente(s) <span className="text-red-500">*</span>
         </label>
-        <div data-testid="clientVM.clients-checkbox-container" className="grid grid-cols-2 sm:grid-cols-3 gap-2 max-h-48 overflow-y-auto border border-gray-200 rounded-lg p-3">
-          {clientVM.clients.filter(c => c.status === 'active').map(client => (
-            <label
-              key={client.id}
-              className="flex items-center space-x-2 cursor-pointer"
-            >
-              <input
-                data-testid={`client-checkbox-${client.id}`}
-                type="checkbox"
-                checked={formData.clientIds.includes(client.id)}
-                onChange={() => handleClientToggle(client.id)}
-                className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-              />
-              <span className="text-sm text-gray-700 truncate">{client.name}</span>
-            </label>
-          ))}
-          {clientVM.clients.filter(c => c.status === 'active').length === 0 && (
-            <p className="text-sm text-gray-400 col-span-full">No hay clientes activos</p>
+        {clientVM.error && (
+          <div data-testid="client-list-error" className="mb-2 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+            {clientVM.error}
+          </div>
+        )}
+        <div data-testid="clients-checkbox-container" className="grid grid-cols-2 sm:grid-cols-3 gap-2 max-h-48 overflow-y-auto border border-gray-200 rounded-lg p-3">
+          {clientVM.isLoading ? (
+            <p data-testid="clients-loading" className="text-sm text-gray-400 col-span-full">Cargando clientes...</p>
+          ) : (
+            <>
+              {clientVM.clients.filter(c => c.status === 'active').map(client => (
+                <label
+                  key={client.id}
+                  className="flex items-center space-x-2 cursor-pointer"
+                >
+                  <input
+                    data-testid={`client-checkbox-${client.id}`}
+                    type="checkbox"
+                    checked={formData.clientIds.includes(client.id)}
+                    onChange={() => handleClientToggle(client.id)}
+                    className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  />
+                  <span className="text-sm text-gray-700 truncate">{client.name}</span>
+                </label>
+              ))}
+              {clientVM.clients.filter(c => c.status === 'active').length === 0 && (
+                <p className="text-sm text-gray-400 col-span-full">No hay clientes activos</p>
+              )}
+            </>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary

Investigating a report that clients weren't loading properly in the "Programas" tab (this tab lives on the trainer dashboard — `diego@nivel.gym` is seeded as a trainer, not a trainee/client).

`CreateProgramForm`'s client checkbox list read `clientVM.clients` but never `clientVM.isLoading` or `clientVM.error`:

- While `clientVM.loadClients()` is in flight (fired once on app mount in `ViewModelProvider`), the list rendered "No hay clientes activos" — identical to a genuinely empty client list, with no way to tell the two apart.
- If the client fetch failed (e.g. RLS denial, network error), `clientVM.error` was set but never displayed, so the failure was completely silent.

Also renamed a stray container `data-testid` that had leaked the `clientVM.clients` variable name into its string (`clientVM.clients-checkbox-container` → `clients-checkbox-container`), for consistency with the rest of the file's testid naming and to avoid confusion. It wasn't referenced by any e2e test.

- Render a "Cargando clientes..." state while `clientVM.isLoading` is true
- Render `clientVM.error` in a banner, matching the existing `programVM.error` pattern in the same file
- Fix the malformed container testid

## Test plan

- [x] `npm run test:run` — 402 tests pass (including existing `CreateProgramForm` unit tests)
- [x] `npm run typecheck` — no errors
- [x] `npm run lint` — no new warnings/errors
- [x] `npm run build` — production build succeeds
- [ ] Manual verification against the live deployment (not possible from this session — network egress to the production URL is blocked in this sandbox)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TUVf69f75PbdZzt4oVeGhA)_